### PR TITLE
Everything/everyone is a tensor, including Ruairi and myself

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -2,7 +2,6 @@
 add_library(device INTERFACE)
 target_sources(device
         PRIVATE
-        gputils.cuh
         tensor.cuh
 )
 target_link_libraries(device

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(device INTERFACE)
 target_sources(device
         PRIVATE
         gputils.cuh
+        tensor.cuh
 )
 target_link_libraries(device
         INTERFACE

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -435,4 +435,24 @@ inline void Tenzor<double>::addAB(Tenzor<double> &A, Tenzor<double> &B, double a
                                  nMat));
 }
 
+template<>
+inline void Tenzor<float>::addAB(Tenzor<float> &A, Tenzor<float> &B, float alpha, float beta) {
+    size_t nMat = A.numMats();
+    size_t nRA = A.numRows();
+    size_t nCA = A.numCols();
+    size_t nCB = B.numCols();
+    Tenzor<float*> ptrA = A.pointersToMatrices();
+    Tenzor<float*> ptrB = B.pointersToMatrices();
+    Tenzor<float*> ptr = pointersToMatrices();
+    float _alpha = alpha, _beta = beta;
+    gpuErrChk(cublasSgemmBatched(Session::getInstance().cuBlasHandle(),
+                                 CUBLAS_OP_N, CUBLAS_OP_N,
+                                 nRA, nCB, nCA, &_alpha,
+                                 ptrA.raw(), nRA,
+                                 ptrB.raw(), nCA,
+                                 &_beta,
+                                 ptr.raw(), nRA,
+                                 nMat));
+}
+
 #endif

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -159,6 +159,16 @@ public:
                              cudaMemcpyDeviceToDevice));
     }
 
+    DTensor(DTensor&& other) {
+        m_numCols = other.m_numCols;
+        m_numRows = other.m_numRows;
+        m_numMats = other.m_numMats;
+        m_d_data = other.m_d_data;
+        m_doDestroy = true;
+        other.m_doDestroy = false;
+        other.m_d_data = nullptr;
+    }
+
     /**
      * Slicing constructor
      * @param other

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -91,7 +91,7 @@ public:
 
 
 template<typename T>
-class Tenzor {
+class DTensor {
 
 private:
     /** Pointer to device data */
@@ -115,9 +115,9 @@ public:
     /**
     * Constructs a DeviceVector object
     */
-    Tenzor() = default;
+    DTensor() = default;
 
-    ~Tenzor() {
+    ~DTensor() {
         destroy();
     }
 
@@ -125,7 +125,7 @@ public:
      * Allocates (m, n, k)-tensor
      * @param n
      */
-    Tenzor(size_t m, size_t n = 1, size_t k = 1, bool zero = false) {
+    DTensor(size_t m, size_t n = 1, size_t k = 1, bool zero = false) {
         m_numRows = m;
         m_numCols = n;
         m_numMats = k;
@@ -133,7 +133,7 @@ public:
         allocateOnDevice(size, zero);
     }
 
-    Tenzor(const std::vector<T> &data, size_t m, size_t n = 1, size_t k = 1) {
+    DTensor(const std::vector<T> &data, size_t m, size_t n = 1, size_t k = 1) {
         m_numRows = m;
         m_numCols = n;
         m_numMats = k;
@@ -145,7 +145,7 @@ public:
     /**
      * Copy constructor
      */
-    Tenzor(const Tenzor &other) {
+    DTensor(const DTensor &other) {
         m_numMats = other.m_numMats;
         m_numRows = other.m_numRows;
         m_numCols = other.m_numCols;
@@ -162,7 +162,7 @@ public:
      * @param from
      * @param to
      */
-    Tenzor(const Tenzor &other, size_t axis, size_t from, size_t to) {
+    DTensor(const DTensor &other, size_t axis, size_t from, size_t to) {
         if (from > to) throw std::invalid_argument("from > to");
         size_t offset = 0, len = to - from + 1;
         if (axis == 2) {
@@ -199,43 +199,43 @@ public:
 
     void download(std::vector<T> &vec) const;
 
-    void deviceCopyTo(Tenzor<T> &other) const;
+    void deviceCopyTo(DTensor<T> &other) const;
 
     T normF() const;
 
     T sumAbs() const;
 
-    void leastSquares(Tenzor &b);
+    void leastSquares(DTensor &b);
 
     /* ------------- OPERATORS ------------- */
 
-    Tenzor &operator=(const Tenzor &other);
+    DTensor &operator=(const DTensor &other);
 
     T operator()(size_t i, size_t j=0, size_t k=0);
 
-    Tenzor &operator*=(T scalar);
+    DTensor &operator*=(T scalar);
 
-    Tenzor &operator+=(const Tenzor &rhs);
+    DTensor &operator+=(const DTensor &rhs);
 
-    Tenzor &operator-=(const Tenzor &rhs);
+    DTensor &operator-=(const DTensor &rhs);
 
-    Tenzor<T *> pointersToMatrices();
+    DTensor<T *> pointersToMatrices();
 
-    friend Tenzor operator+(Tenzor &first, const Tenzor &second) {
-        Tenzor result(first);
+    friend DTensor operator+(DTensor &first, const DTensor &second) {
+        DTensor result(first);
         result += second;
         return result;
     }
 
-    friend Tenzor operator-(Tenzor &first, const Tenzor &second) {
-        Tenzor result(first);
+    friend DTensor operator-(DTensor &first, const DTensor &second) {
+        DTensor result(first);
         result -= second;
         return result;
     }
 
-    void addAB(Tenzor<T> &A, Tenzor<T> &B, T alpha = 1, T beta = 0);
+    void addAB(DTensor<T> &A, DTensor<T> &B, T alpha = 1, T beta = 0);
 
-    friend std::ostream &operator<<(std::ostream &out, const Tenzor<T> &data) {
+    friend std::ostream &operator<<(std::ostream &out, const DTensor<T> &data) {
         size_t nr = data.m_numRows, nc = data.m_numCols, nm = data.m_numMats;
         out << "Tensor [" << data.m_numRows << " x "
             << data.m_numCols << " x "
@@ -257,27 +257,27 @@ public:
 }; /* END OF TENZOR */
 
 template<typename T>
-inline size_t Tenzor<T>::numRows() const {
+inline size_t DTensor<T>::numRows() const {
     return m_numRows;
 }
 
 template<typename T>
-inline size_t Tenzor<T>::numCols() const {
+inline size_t DTensor<T>::numCols() const {
     return m_numCols;
 }
 
 template<typename T>
-inline size_t Tenzor<T>::numMats() const {
+inline size_t DTensor<T>::numMats() const {
     return m_numMats;
 }
 
 template<typename T>
-inline size_t Tenzor<T>::numel() const {
+inline size_t DTensor<T>::numel() const {
     return m_numRows * m_numCols * m_numMats;
 }
 
 template<>
-inline double Tenzor<double>::normF() const {
+inline double DTensor<double>::normF() const {
     double the_norm;
     gpuErrChk(cublasDnrm2(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, m_d_data, 1,
                           &the_norm));
@@ -285,7 +285,7 @@ inline double Tenzor<double>::normF() const {
 }
 
 template<>
-inline float Tenzor<float>::normF() const {
+inline float DTensor<float>::normF() const {
     float the_norm;
     gpuErrChk(cublasSnrm2(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, m_d_data, 1,
                           &the_norm));
@@ -294,7 +294,7 @@ inline float Tenzor<float>::normF() const {
 
 
 template<>
-inline float Tenzor<float>::sumAbs() const {
+inline float DTensor<float>::sumAbs() const {
     float sumAbsAllElements;
     gpuErrChk(cublasSasum(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, m_d_data, 1,
                           &sumAbsAllElements));
@@ -302,7 +302,7 @@ inline float Tenzor<float>::sumAbs() const {
 }
 
 template<>
-inline double Tenzor<double>::sumAbs() const {
+inline double DTensor<double>::sumAbs() const {
     double sumAbsAllElements;
     gpuErrChk(cublasDasum(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, m_d_data, 1,
                           &sumAbsAllElements));
@@ -310,7 +310,7 @@ inline double Tenzor<double>::sumAbs() const {
 }
 
 template<typename T>
-inline bool Tenzor<T>::allocateOnDevice(size_t size, bool zero) {
+inline bool DTensor<T>::allocateOnDevice(size_t size, bool zero) {
     if (size <= 0) return false;
     destroy();
     m_doDestroy = true;
@@ -322,7 +322,7 @@ inline bool Tenzor<T>::allocateOnDevice(size_t size, bool zero) {
 }
 
 template<typename T>
-inline bool Tenzor<T>::upload(const std::vector<T> &vec) {
+inline bool DTensor<T>::upload(const std::vector<T> &vec) {
     size_t size = vec.size();
     // make sure vec is of right size
     if (size != m_numRows * m_numCols * m_numMats) throw std::invalid_argument("vec has wrong size");
@@ -334,7 +334,7 @@ inline bool Tenzor<T>::upload(const std::vector<T> &vec) {
 }
 
 template<typename T>
-inline void Tenzor<T>::download(std::vector<T> &vec) const {
+inline void DTensor<T>::download(std::vector<T> &vec) const {
     vec.resize(m_numRows * m_numCols * m_numMats);
     gpuErrChk(cudaMemcpy(vec.data(),
                          m_d_data,
@@ -343,12 +343,12 @@ inline void Tenzor<T>::download(std::vector<T> &vec) const {
 }
 
 template<typename T>
-inline T *Tenzor<T>::raw() const {
+inline T *DTensor<T>::raw() const {
     return m_d_data;
 }
 
 template<typename T>
-inline void Tenzor<T>::deviceCopyTo(Tenzor<T> &elsewhere) const {
+inline void DTensor<T>::deviceCopyTo(DTensor<T> &elsewhere) const {
     if (elsewhere.numel() < numel()) {
         throw std::invalid_argument("tensor does not fit into destination");
     }
@@ -359,7 +359,7 @@ inline void Tenzor<T>::deviceCopyTo(Tenzor<T> &elsewhere) const {
 }
 
 template<>
-inline Tenzor<double> &Tenzor<double>::operator*=(double scalar) {
+inline DTensor<double> &DTensor<double>::operator*=(double scalar) {
     double alpha = scalar;
     gpuErrChk(
             cublasDscal(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, &alpha, m_d_data, 1));
@@ -367,7 +367,7 @@ inline Tenzor<double> &Tenzor<double>::operator*=(double scalar) {
 }
 
 template<typename T>
-Tenzor<T> &Tenzor<T>::operator=(const Tenzor<T> &other) {
+DTensor<T> &DTensor<T>::operator=(const DTensor<T> &other) {
     m_numMats = other.m_numMats;
     m_numRows = other.m_numRows;
     m_numCols = other.m_numCols;
@@ -377,7 +377,7 @@ Tenzor<T> &Tenzor<T>::operator=(const Tenzor<T> &other) {
 }
 
 template<>
-inline Tenzor<float> &Tenzor<float>::operator*=(float scalar) {
+inline DTensor<float> &DTensor<float>::operator*=(float scalar) {
     float alpha = scalar;
     gpuErrChk(
             cublasSscal(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, &alpha, m_d_data, 1));
@@ -385,7 +385,7 @@ inline Tenzor<float> &Tenzor<float>::operator*=(float scalar) {
 }
 
 template<>
-inline Tenzor<double> &Tenzor<double>::operator+=(const Tenzor<double> &rhs) {
+inline DTensor<double> &DTensor<double>::operator+=(const DTensor<double> &rhs) {
     const double alpha = 1.;
     gpuErrChk(
             cublasDaxpy(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, &alpha, rhs.m_d_data,
@@ -394,7 +394,7 @@ inline Tenzor<double> &Tenzor<double>::operator+=(const Tenzor<double> &rhs) {
 }
 
 template<>
-inline Tenzor<float> &Tenzor<float>::operator+=(const Tenzor<float> &rhs) {
+inline DTensor<float> &DTensor<float>::operator+=(const DTensor<float> &rhs) {
     const float alpha = 1.;
     gpuErrChk(
             cublasSaxpy(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, &alpha, rhs.m_d_data,
@@ -403,7 +403,7 @@ inline Tenzor<float> &Tenzor<float>::operator+=(const Tenzor<float> &rhs) {
 }
 
 template<>
-inline Tenzor<float> &Tenzor<float>::operator-=(const Tenzor<float> &rhs) {
+inline DTensor<float> &DTensor<float>::operator-=(const DTensor<float> &rhs) {
     const float alpha = -1.;
     cublasSaxpy(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, &alpha, rhs.m_d_data, 1,
                 m_d_data, 1);
@@ -411,7 +411,7 @@ inline Tenzor<float> &Tenzor<float>::operator-=(const Tenzor<float> &rhs) {
 }
 
 template<>
-inline Tenzor<double> &Tenzor<double>::operator-=(const Tenzor<double> &rhs) {
+inline DTensor<double> &DTensor<double>::operator-=(const DTensor<double> &rhs) {
     const double alpha = -1.;
     gpuErrChk(
             cublasDaxpy(Session::getInstance().cuBlasHandle(), m_numRows * m_numCols * m_numMats, &alpha, rhs.m_d_data,
@@ -420,7 +420,7 @@ inline Tenzor<double> &Tenzor<double>::operator-=(const Tenzor<double> &rhs) {
 }
 
 template<typename T>
-inline T Tenzor<T>::operator()(size_t i, size_t j, size_t k) {
+inline T DTensor<T>::operator()(size_t i, size_t j, size_t k) {
     T hostDst;
     size_t offset = i + m_numRows * (j + m_numCols * k);
     gpuErrChk(cudaMemcpy(&hostDst, m_d_data + offset, sizeof(T), cudaMemcpyDeviceToHost));
@@ -428,26 +428,26 @@ inline T Tenzor<T>::operator()(size_t i, size_t j, size_t k) {
 }
 
 template<typename T>
-inline Tenzor<T *> Tenzor<T>::pointersToMatrices() {
+inline DTensor<T *> DTensor<T>::pointersToMatrices() {
     std::vector<T *> h_pointers(m_numMats);
     size_t numelMat = m_numRows * m_numCols;
     h_pointers[0] = m_d_data;
     for (size_t i = 1; i < m_numMats; i++) {
         h_pointers[i] = m_d_data + i * numelMat;
     }
-    Tenzor<T *> t(h_pointers, m_numMats, 1, 1);
+    DTensor<T *> t(h_pointers, m_numMats, 1, 1);
     return t;
 }
 
 template<>
-inline void Tenzor<double>::addAB(Tenzor<double> &A, Tenzor<double> &B, double alpha, double beta) {
+inline void DTensor<double>::addAB(DTensor<double> &A, DTensor<double> &B, double alpha, double beta) {
     size_t nMat = A.numMats();
     size_t nRA = A.numRows();
     size_t nCA = A.numCols();
     size_t nCB = B.numCols();
-    Tenzor<double *> ptrA = A.pointersToMatrices();
-    Tenzor<double *> ptrB = B.pointersToMatrices();
-    Tenzor<double *> ptr = pointersToMatrices();
+    DTensor<double *> ptrA = A.pointersToMatrices();
+    DTensor<double *> ptrB = B.pointersToMatrices();
+    DTensor<double *> ptr = pointersToMatrices();
     double _alpha = alpha, _beta = beta;
     gpuErrChk(cublasDgemmBatched(Session::getInstance().cuBlasHandle(),
                                  CUBLAS_OP_N, CUBLAS_OP_N,
@@ -460,14 +460,14 @@ inline void Tenzor<double>::addAB(Tenzor<double> &A, Tenzor<double> &B, double a
 }
 
 template<>
-inline void Tenzor<float>::addAB(Tenzor<float> &A, Tenzor<float> &B, float alpha, float beta) {
+inline void DTensor<float>::addAB(DTensor<float> &A, DTensor<float> &B, float alpha, float beta) {
     size_t nMat = A.numMats();
     size_t nRA = A.numRows();
     size_t nCA = A.numCols();
     size_t nCB = B.numCols();
-    Tenzor<float *> ptrA = A.pointersToMatrices();
-    Tenzor<float *> ptrB = B.pointersToMatrices();
-    Tenzor<float *> ptr = pointersToMatrices();
+    DTensor<float *> ptrA = A.pointersToMatrices();
+    DTensor<float *> ptrB = B.pointersToMatrices();
+    DTensor<float *> ptr = pointersToMatrices();
     float _alpha = alpha, _beta = beta;
     gpuErrChk(cublasSgemmBatched(Session::getInstance().cuBlasHandle(),
                                  CUBLAS_OP_N, CUBLAS_OP_N,
@@ -480,7 +480,7 @@ inline void Tenzor<float>::addAB(Tenzor<float> &A, Tenzor<float> &B, float alpha
 }
 
 template<>
-inline void Tenzor<double>::leastSquares(Tenzor &B) {
+inline void DTensor<double>::leastSquares(DTensor &B) {
     size_t batchSize = numMats();
     size_t nColsB = B.numCols();
     if (B.numRows() != m_numRows || nColsB != 1 || B.numMats() != batchSize)
@@ -488,9 +488,9 @@ inline void Tenzor<double>::leastSquares(Tenzor &B) {
     if (m_numCols > m_numRows)
         throw std::invalid_argument("Least squares supports tall matrices only");
     int info = 0;
-    Tenzor<int> infoArray(batchSize);
-    Tenzor<double *> As = pointersToMatrices();
-    Tenzor<double *> Bs = B.pointersToMatrices();
+    DTensor<int> infoArray(batchSize);
+    DTensor<double *> As = pointersToMatrices();
+    DTensor<double *> Bs = B.pointersToMatrices();
     gpuErrChk(cublasDgelsBatched(Session::getInstance().cuBlasHandle(),
                                  CUBLAS_OP_N,
                                  m_numRows,
@@ -506,7 +506,7 @@ inline void Tenzor<double>::leastSquares(Tenzor &B) {
 }
 
 template<>
-inline void Tenzor<float>::leastSquares(Tenzor &B) {
+inline void DTensor<float>::leastSquares(DTensor &B) {
     size_t batchSize = numMats();
     size_t nColsB = B.numCols();
     if (B.numRows() != m_numRows || nColsB != 1 || B.numMats() != batchSize)
@@ -514,9 +514,9 @@ inline void Tenzor<float>::leastSquares(Tenzor &B) {
     if (m_numCols > m_numRows)
         throw std::invalid_argument("Least squares supports tall matrices only");
     int info = 0;
-    Tenzor<int> infoArray(batchSize);
-    Tenzor<float *> As = pointersToMatrices();
-    Tenzor<float *> Bs = B.pointersToMatrices();
+    DTensor<int> infoArray(batchSize);
+    DTensor<float *> As = pointersToMatrices();
+    DTensor<float *> Bs = B.pointersToMatrices();
     gpuErrChk(cublasSgelsBatched(Session::getInstance().cuBlasHandle(),
                                  CUBLAS_OP_N,
                                  m_numRows,
@@ -560,13 +560,13 @@ class Svd {
 private:
 
     int m_lwork = -1; /**< size of workspace needed for SVD */
-    Tenzor<T> *m_tensor = nullptr;  /**< pointer to original matrix to be factorised */
-    std::unique_ptr<Tenzor<T>> m_Vtr;  /**< matrix V' or right singular vectors */
-    std::unique_ptr<Tenzor<T>> m_S;
-    std::unique_ptr<Tenzor<T>> m_U;  /**< matrix U or left singular vectors*/
-    std::unique_ptr<Tenzor<T>> m_workspace;  /**< workspace vector */
-    std::unique_ptr<Tenzor<int>> m_info;  /**< status code of computation */
-    std::unique_ptr<Tenzor<unsigned int>> m_rank;
+    DTensor<T> *m_tensor = nullptr;  /**< pointer to original matrix to be factorised */
+    std::unique_ptr<DTensor<T>> m_Vtr;  /**< matrix V' or right singular vectors */
+    std::unique_ptr<DTensor<T>> m_S;
+    std::unique_ptr<DTensor<T>> m_U;  /**< matrix U or left singular vectors*/
+    std::unique_ptr<DTensor<T>> m_workspace;  /**< workspace vector */
+    std::unique_ptr<DTensor<int>> m_info;  /**< status code of computation */
+    std::unique_ptr<DTensor<unsigned int>> m_rank;
     bool m_computeU = false;  /**< whether to compute U */
     bool m_destroyMatrix = true; /**< whether to sacrifice original matrix */
 
@@ -574,7 +574,7 @@ private:
      * Checks whether matrix is tall; throws invalid_argument if not
      * @param mat given matrix
      */
-    void checkMatrix(Tenzor<T> &tenz) {
+    void checkMatrix(DTensor<T> &tenz) {
         if (tenz.numMats() > 1) {
             throw std::invalid_argument("Only (m, n, 1) tensors are supported for now");
         }
@@ -592,23 +592,23 @@ public:
      * @param mat matrix to be factorised
      * @param computeU whether to compute U (default is false)
      */
-    Svd(Tenzor<T> &mat,
+    Svd(DTensor<T> &mat,
         bool computeU = false,
         bool destroyMatrix = true) {
         checkMatrix(mat);
         m_destroyMatrix = destroyMatrix;
-        m_tensor = (destroyMatrix) ? &mat : new Tenzor<T>(mat);
+        m_tensor = (destroyMatrix) ? &mat : new DTensor<T>(mat);
         m_computeU = computeU;
         size_t m = mat.numRows();
         size_t n = mat.numCols();
         size_t k = std::min(m, n);
         computeWorkspaceSize(m, n);
-        m_workspace = std::make_unique<Tenzor<T>>(m_lwork, 1, 1);
-        m_Vtr = std::make_unique<Tenzor<T>>(n, n, 1);
-        m_S = std::make_unique<Tenzor<T>>(k, 1, 1);
-        m_info = std::make_unique<Tenzor<int>>(1, 1, 1);
-        m_rank = std::make_unique<Tenzor<unsigned int>>(1, 1, 1);
-        if (computeU) m_U = std::make_unique<Tenzor<T>>(m, m, 1);
+        m_workspace = std::make_unique<DTensor<T>>(m_lwork, 1, 1);
+        m_Vtr = std::make_unique<DTensor<T>>(n, n, 1);
+        m_S = std::make_unique<DTensor<T>>(k, 1, 1);
+        m_info = std::make_unique<DTensor<int>>(1, 1, 1);
+        m_rank = std::make_unique<DTensor<unsigned int>>(1, 1, 1);
+        if (computeU) m_U = std::make_unique<DTensor<T>>(m, m, 1);
     }
 
     /**
@@ -619,15 +619,15 @@ public:
      */
     int factorise();
 
-    Tenzor<T> singularValues() const {
+    DTensor<T> singularValues() const {
         return *m_S;
     }
 
-    Tenzor<T> rightSingularVectors() const {
+    DTensor<T> rightSingularVectors() const {
         return *m_Vtr;
     }
 
-    std::optional<Tenzor<T>> leftSingularVectors() const {
+    std::optional<DTensor<T>> leftSingularVectors() const {
         if (!m_computeU) return std::nullopt;
         return *m_U;
     }

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -107,6 +107,30 @@ public:
         cudaMemcpy(m_d_data, other.raw(), m_numAllocatedElements * sizeof(T), cudaMemcpyDeviceToDevice);
     }
 
+    Tenzor(const Tenzor &other, size_t axis, size_t from, size_t to) {
+        if (from > to) throw std::invalid_argument("from > to");
+        size_t offset = 0;
+        if (axis == 2) {
+            offset = other.m_numRows * other.m_numCols * from;
+            m_numRows = other.m_numRows;
+            m_numCols = other.m_numCols;
+            m_numMats = to - from + 1;
+        } else if (axis == 1) {
+            offset = other.m_numCols * from;
+            m_numRows = other.m_numRows;
+            m_numCols = to - from + 1;
+            m_numMats = 1;
+        } else if (axis == 0) {
+            offset = from;
+            m_numRows = to - from + 1;
+            m_numCols = 1;
+            m_numMats = 1;
+        }
+        m_d_data = other.m_d_data + offset;
+        m_numAllocatedElements = m_numRows * m_numCols * m_numMats;
+        m_doDestroy = false;
+    }
+
     T *raw() const;
 
     size_t numRows() const;
@@ -124,7 +148,6 @@ public:
     void deviceCopyTo(Tenzor<T> &other) const;
 
     T normF() const;
-
 
     /* OPERATORS */
     Tenzor &operator=(const Tenzor &other) {

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -203,16 +203,11 @@ public:
 
     T normF() const;
 
+    void leastSquares(Tenzor &b);
+
     /* ------------- OPERATORS ------------- */
 
-    Tenzor &operator=(const Tenzor &other) {
-        m_numMats = other.m_numMats;
-        m_numRows = other.m_numRows;
-        m_numCols = other.m_numCols;
-        m_doDestroy = false;
-        m_d_data = other.m_d_data;
-        return *this;
-    }
+    Tenzor &operator=(const Tenzor &other);
 
     T operator()(size_t i, size_t j, size_t k);
 
@@ -222,7 +217,7 @@ public:
 
     Tenzor &operator-=(const Tenzor &rhs);
 
-    Tenzor<T*> pointersToMatrices();
+    Tenzor<T *> pointersToMatrices();
 
     friend Tenzor operator+(Tenzor &first, const Tenzor &second) {
         Tenzor result(first);
@@ -352,6 +347,16 @@ inline Tenzor<double> &Tenzor<double>::operator*=(double scalar) {
     return *this;
 }
 
+template<typename T>
+Tenzor<T> &Tenzor<T>::operator=(const Tenzor<T> &other) {
+    m_numMats = other.m_numMats;
+    m_numRows = other.m_numRows;
+    m_numCols = other.m_numCols;
+    m_doDestroy = false;
+    m_d_data = other.m_d_data;
+    return *this;
+}
+
 template<>
 inline Tenzor<float> &Tenzor<float>::operator*=(float scalar) {
     float alpha = scalar;
@@ -404,14 +409,14 @@ inline T Tenzor<T>::operator()(size_t i, size_t j, size_t k) {
 }
 
 template<typename T>
-inline Tenzor<T*> Tenzor<T>::pointersToMatrices() {
-    std::vector<T*> h_pointers(m_numMats);
+inline Tenzor<T *> Tenzor<T>::pointersToMatrices() {
+    std::vector<T *> h_pointers(m_numMats);
     size_t numelMat = m_numRows * m_numCols;
     h_pointers[0] = m_d_data;
-    for (size_t i = 1; i < m_numMats; i++)  {
+    for (size_t i = 1; i < m_numMats; i++) {
         h_pointers[i] = m_d_data + i * numelMat;
     }
-    Tenzor<T*> t(h_pointers, m_numMats, 1, 1);
+    Tenzor<T *> t(h_pointers, m_numMats, 1, 1);
     return t;
 }
 
@@ -421,9 +426,9 @@ inline void Tenzor<double>::addAB(Tenzor<double> &A, Tenzor<double> &B, double a
     size_t nRA = A.numRows();
     size_t nCA = A.numCols();
     size_t nCB = B.numCols();
-    Tenzor<double*> ptrA = A.pointersToMatrices();
-    Tenzor<double*> ptrB = B.pointersToMatrices();
-    Tenzor<double*> ptr = pointersToMatrices();
+    Tenzor<double *> ptrA = A.pointersToMatrices();
+    Tenzor<double *> ptrB = B.pointersToMatrices();
+    Tenzor<double *> ptr = pointersToMatrices();
     double _alpha = alpha, _beta = beta;
     gpuErrChk(cublasDgemmBatched(Session::getInstance().cuBlasHandle(),
                                  CUBLAS_OP_N, CUBLAS_OP_N,
@@ -441,9 +446,9 @@ inline void Tenzor<float>::addAB(Tenzor<float> &A, Tenzor<float> &B, float alpha
     size_t nRA = A.numRows();
     size_t nCA = A.numCols();
     size_t nCB = B.numCols();
-    Tenzor<float*> ptrA = A.pointersToMatrices();
-    Tenzor<float*> ptrB = B.pointersToMatrices();
-    Tenzor<float*> ptr = pointersToMatrices();
+    Tenzor<float *> ptrA = A.pointersToMatrices();
+    Tenzor<float *> ptrB = B.pointersToMatrices();
+    Tenzor<float *> ptr = pointersToMatrices();
     float _alpha = alpha, _beta = beta;
     gpuErrChk(cublasSgemmBatched(Session::getInstance().cuBlasHandle(),
                                  CUBLAS_OP_N, CUBLAS_OP_N,
@@ -453,6 +458,178 @@ inline void Tenzor<float>::addAB(Tenzor<float> &A, Tenzor<float> &B, float alpha
                                  &_beta,
                                  ptr.raw(), nRA,
                                  nMat));
+}
+
+template<>
+inline void Tenzor<double>::leastSquares(Tenzor &B) {
+    size_t batchSize = numMats();
+    size_t nColsB = B.numCols();
+    if (B.numRows() != m_numRows || nColsB != 1 || B.numMats() != batchSize)
+        throw std::invalid_argument("Least squares rhs size does not equal lhs size");
+    if (m_numCols > m_numRows)
+        throw std::invalid_argument("Least squares supports tall matrices only");
+    int info = 0;
+    Tenzor<int> infoArray(batchSize);
+    Tenzor<double *> As = pointersToMatrices();
+    Tenzor<double *> Bs = B.pointersToMatrices();
+    gpuErrChk(cublasDgelsBatched(Session::getInstance().cuBlasHandle(),
+                                 CUBLAS_OP_N,
+                                 m_numRows,
+                                 m_numCols,
+                                 nColsB,
+                                 As.raw(),
+                                 m_numRows,
+                                 Bs.raw(),
+                                 m_numRows,
+                                 &info,
+                                 infoArray.raw(),
+                                 batchSize));
+}
+
+template<>
+inline void Tenzor<float>::leastSquares(Tenzor &B) {
+    size_t batchSize = numMats();
+    size_t nColsB = B.numCols();
+    if (B.numRows() != m_numRows || nColsB != 1 || B.numMats() != batchSize)
+        throw std::invalid_argument("Least squares rhs size does not equal lhs size");
+    if (m_numCols > m_numRows)
+        throw std::invalid_argument("Least squares supports tall matrices only");
+    int info = 0;
+    Tenzor<int> infoArray(batchSize);
+    Tenzor<float *> As = pointersToMatrices();
+    Tenzor<float *> Bs = B.pointersToMatrices();
+    gpuErrChk(cublasSgelsBatched(Session::getInstance().cuBlasHandle(),
+                                 CUBLAS_OP_N,
+                                 m_numRows,
+                                 m_numCols,
+                                 nColsB,
+                                 As.raw(),
+                                 m_numRows,
+                                 Bs.raw(),
+                                 m_numRows,
+                                 &info,
+                                 infoArray.raw(),
+                                 batchSize));
+}
+
+
+template<typename T> requires std::floating_point<T>
+class Svd {
+
+private:
+
+    int m_lwork = -1; /**< size of workspace needed for SVD */
+    Tenzor<T> *m_tensor = nullptr;  /**< pointer to original matrix to be factorised */
+    std::unique_ptr<Tenzor<T>> m_Vtr;  /**< matrix V' or right singular vectors */
+    std::unique_ptr<Tenzor<T>> m_S;
+    std::unique_ptr<Tenzor<T>> m_U;  /**< matrix U or left singular vectors*/
+    std::unique_ptr<Tenzor<T>> m_workspace;  /**< workspace vector */
+    std::unique_ptr<Tenzor<int>> m_info;  /**< status code of computation */
+    std::unique_ptr<Tenzor<unsigned int>> m_rank;
+    bool m_computeU = false;  /**< whether to compute U */
+    bool m_destroyMatrix = true; /**< whether to sacrifice original matrix */
+
+    /**
+     * Checks whether matrix is tall; throws invalid_argument if not
+     * @param mat given matrix
+     */
+    void checkMatrix(Tenzor<T> &tenz) {
+        if (tenz.numMats() > 1) {
+            throw std::invalid_argument("Only (m, n, 1) tensors are supported for now");
+        }
+        if (tenz.numRows() < tenz.numCols()) {
+            throw std::invalid_argument("your matrix is fat (no offence)");
+        }
+    };
+
+    void computeWorkspaceSize(size_t m, size_t n);
+
+public:
+
+    /**
+     * Constructor
+     * @param mat matrix to be factorised
+     * @param computeU whether to compute U (default is false)
+     */
+    Svd(Tenzor<T> &mat,
+        bool computeU = false,
+        bool destroyMatrix = true) {
+        checkMatrix(mat);
+        m_destroyMatrix = destroyMatrix;
+        m_tensor = (destroyMatrix) ? &mat : new Tenzor<T>(mat);
+        m_computeU = computeU;
+        size_t m = mat.numRows();
+        size_t n = mat.numCols();
+        size_t k = std::min(m, n);
+        computeWorkspaceSize(m, n);
+        m_workspace = std::make_unique<Tenzor<T>>(m_lwork, 1, 1);
+        m_Vtr = std::make_unique<Tenzor<T>>(n, n, 1);
+        m_S = std::make_unique<Tenzor<T>>(k, 1, 1);
+        m_info = std::make_unique<Tenzor<int>>(1, 1, 1);
+        m_rank = std::make_unique<Tenzor<unsigned int>>(1, 1, 1);
+        if (computeU) m_U = std::make_unique<Tenzor<T>>(m, m, 1);
+    }
+
+    /**
+     * Perform factorisation
+     * @return status code
+     *
+     * Warning: the given matrix is destroyed
+     */
+    int factorise();
+
+    Tenzor<T> singularValues() const {
+        return *m_S;
+    }
+
+    Tenzor<T> rightSingularVectors() const {
+        return *m_Vtr;
+    }
+
+    std::optional<Tenzor<T>> leftSingularVectors() const {
+        if (!m_computeU) return std::nullopt;
+        return *m_U;
+    }
+
+    ~Svd() {
+        m_lwork = -1;
+        if (!m_destroyMatrix && m_tensor) delete m_tensor;
+    }
+
+    unsigned int rank(T epsilon = 1e-6);
+
+};
+
+
+template<>
+inline void Svd<float>::computeWorkspaceSize(size_t m, size_t n) {
+    gpuErrChk(cusolverDnSgesvd_bufferSize(Context::getInstance().cuSolverHandle(), m, n, &m_lwork));
+}
+
+template<>
+inline void Svd<double>::computeWorkspaceSize(size_t m, size_t n) {
+    gpuErrChk(cusolverDnDgesvd_bufferSize(Context::getInstance().cuSolverHandle(), m, n, &m_lwork));
+}
+
+
+template<>
+inline int Svd<double>::factorise() {
+    size_t m = m_tensor->numRows();
+    size_t n = m_tensor->numCols();
+    gpuErrChk(
+            cusolverDnDgesvd(Context::getInstance().cuSolverHandle(),
+                             (m_computeU) ? 'A' : 'N', 'A',
+                             m, n,
+                             m_tensor->raw(), m,
+                             m_S->raw(),
+                             (m_computeU) ? m_U->raw() : nullptr, m,
+                             m_Vtr->raw(), n,
+                             m_workspace->raw(),
+                             m_lwork,
+                             nullptr,  // rwork (used only if SVD fails)
+                             m_info->raw()));
+    int info = (*m_info)(0, 0, 0);
+    return info;
 }
 
 #endif

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -1,0 +1,178 @@
+#include <vector>
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <cublas_v2.h>
+#include <cusolverDn.h>
+#include <stdexcept>
+#include <memory>
+#include <optional>
+#include <source_location>
+
+#ifndef TENSOR_CUH
+#define TENSOR_CUH
+
+
+/* ------------------------------------------------------------------------------------
+ *  Context
+ * ------------------------------------------------------------------------------------ */
+
+
+class Session {
+public:
+    static Session &getInstance() {
+        static Session instance;
+        return instance;
+    }
+
+private:
+    Session() {
+        cublasCreate(&m_cublasHandle);
+        cusolverDnCreate(&m_cusolverHandle);
+    }
+
+    ~Session() {
+        cublasDestroy(m_cublasHandle);
+        cusolverDnDestroy(m_cusolverHandle);
+    }
+
+    cublasHandle_t m_cublasHandle;
+    cusolverDnHandle_t m_cusolverHandle;
+
+
+public:
+    Session(Session const &) = delete;
+
+    void operator=(Session const &) = delete;
+
+    cublasHandle_t &cuBlasHandle() { return m_cublasHandle; }
+
+    cusolverDnHandle_t &cuSolverHandle() { return m_cusolverHandle; }
+};
+
+
+template<typename T>
+class Tenzor {
+
+private:
+    /** Pointer to device data */
+    T *m_d_data = nullptr;
+    /** Number of allocated elements */
+    size_t m_numAllocatedElements = 0;
+    size_t m_numRows = 0;
+    size_t m_numCols = 0;
+    size_t m_numMats = 0;
+    bool m_doDestroy = false;
+
+    bool destroy() {
+        if (!m_doDestroy) return false;
+        if (m_d_data) cudaFree(m_d_data);
+        m_numAllocatedElements = 0;
+        m_d_data = nullptr;
+        return true;
+    }
+
+public:
+    /**
+    * Constructs a DeviceVector object
+    */
+    Tenzor() = default;
+
+    /**
+     * Allocates (m, n, k)-tensor
+     * @param n
+     */
+    Tenzor(size_t m, size_t n = 1, size_t k = 1) {
+        m_numRows = m;
+        m_numCols = n;
+        m_numMats = k;
+        size_t size = m * n * k;
+        allocateOnDevice(size);
+    }
+
+    bool allocateOnDevice(size_t size);
+
+    T *raw();
+
+    bool upload(const T *dataArray, size_t size);
+
+    bool upload(const std::vector<T> &vec);
+
+    void download(T *hostData) const;
+
+    void download(std::vector<T> &vec) const;
+
+    friend std::ostream &operator<<(std::ostream &out, const Tenzor<T> &data) {
+        size_t nr = data.m_numRows, nc = data.m_numCols, nm = data.m_numMats;
+        out << "Tensor [" << data.m_numRows << " x "
+            << data.m_numCols << " x "
+            << data.m_numMats << "]:" << std::endl;
+        std::vector<T> temp;
+        data.download(temp);
+        for (size_t k = 0; k < nm; k++) {
+            out << ">> layer: " << k << std::endl;
+            for (size_t i = 0; i < nr ; i++) {
+                for (size_t j = 0; j < nc; j++) {
+                    out << std::setw(10) << temp[nr * (nc * k + j) + i] << ", ";
+                }
+                out << std::endl;
+            }
+        }
+//        for (size_t i = 0; i < data.m_numAllocatedElements - 1; i++) {
+//            out << std::setw(10) << temp[i] << std::endl;
+//        }
+//        out << std::setw(10) << temp[data.m_numAllocatedElements - 1] << std::endl;
+        return out;
+    }
+
+}; /* END OF TENZOR */
+
+
+template<typename T>
+inline bool Tenzor<T>::allocateOnDevice(size_t size) {
+    if (size <= 0) return false;
+    if (size <= m_numAllocatedElements) return true;
+    destroy();
+    m_doDestroy = true;
+    size_t buffer_size = size * sizeof(T);
+    bool cudaStatus = cudaMalloc(&m_d_data, buffer_size);
+    if (cudaStatus != cudaSuccess) return false;
+    m_numAllocatedElements = size;
+    return true;
+}
+
+template<typename T>
+bool Tenzor<T>::upload(const std::vector<T> &vec) {
+    return upload(vec.data(), vec.size());
+}
+
+template<typename T>
+bool Tenzor<T>::upload(const T *dataArray, size_t size) {
+    if (!this->allocateOnDevice(size)) return false;
+    if (size <= m_numAllocatedElements) {
+        size_t buffer_size = size * sizeof(T);
+        cudaMemcpy(m_d_data, dataArray, buffer_size, cudaMemcpyHostToDevice);
+    }
+    return true;
+}
+
+template<typename T>
+void Tenzor<T>::download(T *hostData) const {
+    cudaMemcpy(hostData,
+               m_d_data,
+               m_numAllocatedElements * sizeof(T),
+               cudaMemcpyDeviceToHost);
+}
+
+template<typename T>
+void Tenzor<T>::download(std::vector<T> &vec) const {
+    vec.reserve(m_numAllocatedElements);
+    download(vec.data());
+}
+
+template<typename T>
+inline T *Tenzor<T>::raw() {
+    return m_d_data;
+}
+
+#endif

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -222,6 +222,20 @@ public:
 
     Tenzor &operator-=(const Tenzor &rhs);
 
+    Tenzor<T*> pointersToMatrices();
+
+    friend Tenzor operator+(Tenzor &first, const Tenzor &second) {
+        Tenzor result(first);
+        result += second;
+        return result;
+    }
+
+    friend Tenzor operator-(Tenzor &first, const Tenzor &second) {
+        Tenzor result(first);
+        result -= second;
+        return result;
+    }
+
     friend std::ostream &operator<<(std::ostream &out, const Tenzor<T> &data) {
         size_t nr = data.m_numRows, nc = data.m_numCols, nm = data.m_numMats;
         out << "Tensor [" << data.m_numRows << " x "
@@ -385,6 +399,18 @@ T Tenzor<T>::operator()(size_t i, size_t j, size_t k) {
     size_t offset = i + m_numRows * (j + m_numCols * k);
     gpuErrChk(cudaMemcpy(&hostDst, m_d_data + offset, sizeof(T), cudaMemcpyDeviceToHost));
     return hostDst;
+}
+
+template<typename T>
+Tenzor<T*> Tenzor<T>::pointersToMatrices() {
+    std::vector<T*> h_pointers(m_numMats);
+    size_t numelMat = m_numRows * m_numCols;
+    h_pointers[0] = m_d_data;
+    for (size_t i = 1; i < m_numMats; i++)  {
+        h_pointers[i] = m_d_data + i * numelMat;
+    }
+    Tenzor<T*> t(h_pointers, m_numMats, 1, 1);
+    return t;
 }
 
 

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -233,6 +233,13 @@ public:
 
     void addAB(DTensor<T> &A, DTensor<T> &B, T alpha = 1, T beta = 0);
 
+    friend DTensor<T> operator*(DTensor &A, DTensor &B) {
+        size_t nrA = A.m_numRows, ncB = B.m_numCols, nmB = B.m_numMats;
+        DTensor<T> result(nrA, ncB, nmB);
+        result.addAB(A, B);
+        return result;
+    }
+
     friend std::ostream &operator<<(std::ostream &out, const DTensor<T> &data) {
         size_t nr = data.m_numRows, nc = data.m_numCols, nm = data.m_numMats;
         out << "Tensor [" << data.m_numRows << " x "
@@ -253,6 +260,7 @@ public:
     }
 
 }; /* END OF TENZOR */
+
 
 template<typename T>
 inline size_t DTensor<T>::numRows() const {

--- a/main.cu
+++ b/main.cu
@@ -1,7 +1,6 @@
 #include <vector>
 #include <iostream>
 #include <cublas_v2.h>
-#include "include/gputils.cuh"
 #include "include/tensor.cuh"
 
 #define real_t double
@@ -16,7 +15,7 @@ int main() {
                          6.0, 7.0, 8.0,
                          6.0, 7.0, 8.0,
                          6.0, 7.0, 8.0,};
-    Tenzor<real_t> B(bData, 8, 3, 1);
+    Tenzor<real_t> B(bData, 8, 3);
     Svd<real_t> svd(B);
     svd.factorise();
     std::cout << svd.singularValues();

--- a/main.cu
+++ b/main.cu
@@ -7,17 +7,12 @@
 
 
 int main() {
-    std::vector<real_t> bData{1.0, 2.0, 3.0,
-                         6.0, 7.0, 8.0,
-                         6.0, 7.0, 8.0,
-                         6.0, 7.0, 8.0,
-                         6.0, 7.0, 8.0,
-                         6.0, 7.0, 8.0,
-                         6.0, 7.0, 8.0,
-                         6.0, 7.0, 8.0,};
-    DTensor<real_t> B(bData, 8, 3);
-    Svd<real_t> svd(B);
-    svd.factorise();
-    std::cout << svd.singularValues();
+    std::vector<real_t> aData{10.0, 2.0, 3.0,
+                         2.0, 20.0, -1.0,
+                         3.0, -1.0, 30.0};
+    DTensor<real_t> A(aData, 3, 3, 1);
+    CholeskyFactoriser<real_t> chol(A);
+    chol.factorise();
+    std::cout << A;
     return 0;
 }

--- a/main.cu
+++ b/main.cu
@@ -9,18 +9,19 @@
 
 int main() {
 
-    Tenzor<real_t> zero(4, 6, 3, true);
-    std::cout << zero;
+    std::vector<real_t> aData = {1, 2, 3, 4, 5, 6,
+                                 7, 8, 9, 10, 11, 12,
+                                 13, 14, 15, 16, 17, 18};
+    std::vector<real_t> bData = {6, 5, 4, 3, 2, 1,
+                                 7, 6, 5, 4, 3, 2,
+                                 1, 2, 1, 5, -6, 8};
+    Tenzor<real_t> A(aData, 2, 3, 3);
+    Tenzor<real_t> B(bData, 3, 2, 3);
+    Tenzor<real_t> C(2, 2, 3, true);
+    C.addAB(A, B);
 
-    std::vector<real_t> tData = {1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 10};
-    Tenzor<real_t> tenz(2, 3, 2);
-    tenz.upload(tData);
-
-
-    Tenzor<real_t> r(tenz, 1, 0, 1); // r = [:, :, 0:0]
-    std::cout << r;
-
-    Tenzor<real_t> f(tenz, 0, 0, 3); // r = [:, :, 0:0]
-    std::cout << f;
+    std::cout << A;
+    std::cout << B;
+    std::cout << C;
     return 0;
 }

--- a/main.cu
+++ b/main.cu
@@ -9,14 +9,36 @@
 
 int main() {
 
-    std::vector<real_t> tData = {1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6};
+    std::vector<real_t> tData = {1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 10};
     Tenzor<real_t> tenz(2, 3, 2);
     tenz.upload(tData);
 
-    std::cout << tenz << std::endl;
+//    std::cout << tenz << std::endl;
     std::vector<real_t> v;
     tenz.download(v);
-    std::cout << v[1] << std::endl;
+//    std::cout << v[1] << std::endl;
 
+    Tenzor<real_t> other(2, 3, 2);
+    tenz.deviceCopyTo(other);
+//    std::cout << other << std::endl;
+
+    other *= 10.;
+//    std::cout << other << std::endl;
+
+    tenz += other;
+//    std::cout << tenz << std::endl;
+
+    other *= 0.24;
+    tenz -= other;
+
+
+    Tenzor<real_t> y;
+    y = tenz;
+    std::cout << y;
+
+    Tenzor<real_t> z(y);
+    std::cout << z;
+
+    std::cout << z.normF();
     return 0;
 }

--- a/main.cu
+++ b/main.cu
@@ -2,46 +2,21 @@
 #include <iostream>
 #include <cublas_v2.h>
 #include "include/gputils.cuh"
+#include "include/tensor.cuh"
 
 #define real_t double
 
 
 int main() {
 
-//    Context context;
-    std::vector<real_t> a1Data = {1.0, 2.0, 3.0,
-                                  6.0, 7.0, 8.0,
-                                  6.0, 7.0, 8.0,
-                                  6.0, 7.0, 8.0};
-    std::vector<real_t> a2Data = {5.0, 2.0, 3.0,
-                                  6.0, 7.0, 9.0,
-                                  6.0, -7.0, 8.0,
-                                  6.0, 0.0, 8.0};
-    DeviceMatrix<real_t> A1(4, a1Data, rowMajor);
-    DeviceMatrix<real_t> A2(4, a2Data, rowMajor);
-    DeviceTensor<real_t> A(4, 3, 2);
-    A.pushBack(A1);
-    A.pushBack(A2);
+    std::vector<real_t> tData = {1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6};
+    Tenzor<real_t> tenz(2, 3, 2);
+    tenz.upload(tData);
 
-
-    std::vector<real_t> b1Data = {5.0, 12.0,
-                                  7.0, 17.0,
-                                  11.0, 97.0};
-    std::vector<real_t> b2Data = {5.0, 12.0,
-                                  7.0, 17.0,
-                                  11.0, 97.0};
-    DeviceMatrix<real_t> B1(3, b1Data, rowMajor);
-    DeviceMatrix<real_t> B2(3, b2Data, rowMajor);
-    DeviceTensor<real_t> B(3, 2, 2);
-    B.pushBack(B1);
-    B.pushBack(B2);
-
-    DeviceMatrix<real_t> C1(4, 2);
-    DeviceMatrix<real_t> C2(4, 2);
-    DeviceTensor<real_t> C(4, 2, 2);
-    C.pushBack(C1);
-    C.pushBack(C2);
-    C.addAB(A, B);
+    std::cout << tenz << std::endl;
+    std::vector<real_t> v;
+    tenz.download(v);
+    std::cout << v[1] << std::endl;
 
     return 0;
 }

--- a/main.cu
+++ b/main.cu
@@ -13,32 +13,11 @@ int main() {
     Tenzor<real_t> tenz(2, 3, 2);
     tenz.upload(tData);
 
-//    std::cout << tenz << std::endl;
-    std::vector<real_t> v;
-    tenz.download(v);
-//    std::cout << v[1] << std::endl;
 
-    Tenzor<real_t> other(2, 3, 2);
-    tenz.deviceCopyTo(other);
-//    std::cout << other << std::endl;
+    Tenzor<real_t> r(tenz, 1, 0, 1); // r = [:, :, 0:0]
+    std::cout << r;
 
-    other *= 10.;
-//    std::cout << other << std::endl;
-
-    tenz += other;
-//    std::cout << tenz << std::endl;
-
-    other *= 0.24;
-    tenz -= other;
-
-
-    Tenzor<real_t> y;
-    y = tenz;
-    std::cout << y;
-
-    Tenzor<real_t> z(y);
-    std::cout << z;
-
-    std::cout << z.normF();
+    Tenzor<real_t> f(tenz, 0, 0, 3); // r = [:, :, 0:0]
+    std::cout << f;
     return 0;
 }

--- a/main.cu
+++ b/main.cu
@@ -9,6 +9,9 @@
 
 int main() {
 
+    Tenzor<real_t> zero(4, 6, 3, true);
+    std::cout << zero;
+
     std::vector<real_t> tData = {1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 10};
     Tenzor<real_t> tenz(2, 3, 2);
     tenz.upload(tData);

--- a/main.cu
+++ b/main.cu
@@ -8,20 +8,17 @@
 
 
 int main() {
-
-    std::vector<real_t> aData = {1, 2, 3, 4, 5, 6,
-                                 7, 8, 9, 10, 11, 12,
-                                 13, 14, 15, 16, 17, 18};
-    std::vector<real_t> bData = {6, 5, 4, 3, 2, 1,
-                                 7, 6, 5, 4, 3, 2,
-                                 1, 2, 1, 5, -6, 8};
-    Tenzor<real_t> A(aData, 2, 3, 3);
-    Tenzor<real_t> B(bData, 3, 2, 3);
-    Tenzor<real_t> C(2, 2, 3, true);
-    C.addAB(A, B);
-
-    std::cout << A;
-    std::cout << B;
-    std::cout << C;
+    std::vector<real_t> bData{1.0, 2.0, 3.0,
+                         6.0, 7.0, 8.0,
+                         6.0, 7.0, 8.0,
+                         6.0, 7.0, 8.0,
+                         6.0, 7.0, 8.0,
+                         6.0, 7.0, 8.0,
+                         6.0, 7.0, 8.0,
+                         6.0, 7.0, 8.0,};
+    Tenzor<real_t> B(bData, 8, 3, 1);
+    Svd<real_t> svd(B);
+    svd.factorise();
+    std::cout << svd.singularValues();
     return 0;
 }

--- a/main.cu
+++ b/main.cu
@@ -15,7 +15,7 @@ int main() {
                          6.0, 7.0, 8.0,
                          6.0, 7.0, 8.0,
                          6.0, 7.0, 8.0,};
-    Tenzor<real_t> B(bData, 8, 3);
+    DTensor<real_t> B(bData, 8, 3);
     Svd<real_t> svd(B);
     svd.factorise();
     std::cout << svd.singularValues();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,6 @@ enable_testing()
 add_executable(device_test)
 target_sources(device_test  # add files
         PRIVATE
-        testGputils.cu
         testTensor.cu
 )
 target_link_libraries(device_test

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(device_test)
 target_sources(device_test  # add files
         PRIVATE
         testGputils.cu
+        testTensor.cu
 )
 target_link_libraries(device_test
         PRIVATE

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -42,6 +42,25 @@ TEST_F(TensorTest, tensorConstructionZero) {
 }
 
 /* ---------------------------------------
+ * Move constructor
+ * --------------------------------------- */
+
+template<typename T>
+void tensorMoveConstructor() {
+    DTensor<T> zero(2, 3, 4, true);
+    DTensor<T> x(std::move(zero));
+    DTensor<T> y(DTensor<T>{100, 10, 1000});
+}
+
+TEST_F(TensorTest, tensorMoveConstructor) {
+    tensorMoveConstructor<float>();
+    tensorMoveConstructor<double>();
+    tensorMoveConstructor<int>();
+    tensorMoveConstructor<int *>();
+    tensorMoveConstructor<double *>();
+}
+
+/* ---------------------------------------
  * New tensor from data (std::vector)
  * Constructor
  * --------------------------------------- */
@@ -448,11 +467,11 @@ TEST_F(TensorTest, tensorAddAB) {
 template<typename T>
 void tensorGetRows() {
     std::vector<T> aData{10.5, 25.0, 60.0,
-                              -21.0, 720.0, -1.0,
-                              11.0, -1.0, 30.0,
-                              5., 6., 7.,
-                              8., 9., 10.,
-                              11., 12., 13};
+                         -21.0, 720.0, -1.0,
+                         11.0, -1.0, 30.0,
+                         5., 6., 7.,
+                         8., 9., 10.,
+                         11., 12., 13};
     DTensor<T> A(aData, 3, 3, 2);
     DTensor<T> Ar0 = A.getRows(1, 1, 0);
     std::vector<T> expected0 = {25., 720., -1.};
@@ -610,7 +629,7 @@ void choleskyFactorisationSolution(T epsilon) {
     std::vector<T> expected = {-0.126805213103205, -0.128566396618528, 0.175061641423036};
     std::vector<T> actual(3);
     sol.download(actual);
-    for (size_t i=0; i<3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);
+    for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);
 
     DTensor<T> error = A * sol;
     error -= rhs;

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -441,6 +441,36 @@ TEST_F(TensorTest, tensorAddAB) {
     tensorAddAB<float>();
 }
 
+/* ---------------------------------------
+ * Tensor: getRows
+ * --------------------------------------- */
+
+template<typename T>
+void tensorGetRows() {
+    std::vector<T> aData{10.5, 25.0, 60.0,
+                              -21.0, 720.0, -1.0,
+                              11.0, -1.0, 30.0,
+                              5., 6., 7.,
+                              8., 9., 10.,
+                              11., 12., 13};
+    DTensor<T> A(aData, 3, 3, 2);
+    DTensor<T> Ar0 = A.getRows(1, 1, 0);
+    std::vector<T> expected0 = {25., 720., -1.};
+    std::vector<T> actual0(3);
+    Ar0.download(actual0);
+    EXPECT_EQ(expected0, actual0);
+
+    DTensor<T> Ar1 = A.getRows(1, 2, 1);
+    std::vector<T> expected1 = {6., 7., 9., 10., 12., 13.};
+    std::vector<T> actual1(6);
+    Ar1.download(actual1);
+    EXPECT_EQ(expected1, actual1);
+}
+
+TEST_F(TensorTest, tensorGetRows) {
+    tensorGetRows<double>();
+}
+
 /* ================================================================================================
  *  LEAST SQUARES TESTS
  * ================================================================================================ */

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -1,0 +1,305 @@
+#include <gtest/gtest.h>
+#include "../include/tensor.cuh"
+
+#define PRECISION 1e-6
+
+
+class TensorTest : public testing::Test {
+protected:
+    TensorTest() {}
+
+    virtual ~TensorTest() {}
+};
+
+#define TENSOR_DATA_234A {1, 2,  3, 4, 5, 6, 7, 8, 9, 8, 7, 10, 5, 4, 3, 2, 1, -1, 4, 3, 4, 3, 4, 8}
+#define TENSOR_DATA_234B {7, -6, 9, 2, 1, 11, 34, -1, -4, -3, 12, 7, 9, 9, 2, 9, -9, -3, 2, 5, 4, -5, 4, 5}
+#define TENSOR_DATA_234APB {8, -4, 12, 6, 6, 17, 41, 7, 5, 5, 19, 17, 14, 13, 5, 11, -8, -4, 6, 8, 8, -2, 8, 13}
+
+/* ---------------------------------------
+ * Zero Tensor (Constructor)
+ * --------------------------------------- */
+
+template<typename T>
+void tensorConstructionZero() {
+    Tenzor<T> zero(2, 3, 4, true);
+    EXPECT_EQ(2, zero.numRows());
+    EXPECT_EQ(3, zero.numCols());
+    EXPECT_EQ(4, zero.numMats());
+    std::vector<T> expectedResult(2 * 3 * 4, 0);
+    std::vector<T> zeroDown(2 * 3 * 4);
+    zero.download(zeroDown);
+    EXPECT_EQ(expectedResult, zeroDown);
+}
+
+TEST_F(TensorTest, tensorConstructionZero) {
+    tensorConstructionZero<float>();
+    tensorConstructionZero<double>();
+    tensorConstructionZero<int>();
+}
+
+/* ---------------------------------------
+ * New tensor from data (std::vector)
+ * Constructor
+ * --------------------------------------- */
+
+template<typename T>
+void tensorConstructionFromVector() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    EXPECT_EQ(2, tenz.numRows());
+    EXPECT_EQ(3, tenz.numCols());
+    EXPECT_EQ(4, tenz.numMats());
+    EXPECT_EQ(2 * 3 * 4, tenz.numel());
+}
+
+TEST_F(TensorTest, tensorConstructionFromVector) {
+    tensorConstructionFromVector<float>();
+    tensorConstructionFromVector<double>();
+    tensorConstructionFromVector<int>();
+}
+
+/* ---------------------------------------
+ * Tensor: Copy constructor
+ * --------------------------------------- */
+
+template<typename T>
+void tensorCopyConstructor() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    Tenzor<T> tenzCp(tenz);
+    EXPECT_EQ(2, tenzCp.numRows());
+    EXPECT_EQ(3, tenzCp.numCols());
+    EXPECT_EQ(4, tenzCp.numMats());
+    EXPECT_EQ(2 * 3 * 4, tenzCp.numel());
+    std::vector<T> tenzDown(2 * 3 * 4);
+    tenzCp.download(tenzDown);
+    EXPECT_EQ(data, tenzDown);
+    EXPECT_NE(tenz.raw(), tenzCp.raw());
+}
+
+TEST_F(TensorTest, tensorCopyConstructor) {
+    tensorCopyConstructor<float>();
+    tensorCopyConstructor<double>();
+    tensorCopyConstructor<int>();
+}
+
+/* ---------------------------------------
+ * Tensor: Slicing constructor
+ * axis = 2 (matrices)
+ * --------------------------------------- */
+
+template<typename T>
+void tensorSlicingConstructorAxis2() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    Tenzor<T> tenzSlice(tenz, 2, 0, 1); // matrices #0 and #1
+    EXPECT_EQ(2, tenzSlice.numRows());
+    EXPECT_EQ(3, tenzSlice.numCols());
+    EXPECT_EQ(2, tenzSlice.numMats());
+    EXPECT_EQ(tenz.raw(), tenzSlice.raw()); // it is indeed a slice
+}
+
+TEST_F(TensorTest, tensorSlicingConstructorAxis2) {
+    tensorSlicingConstructorAxis2<float>();
+    tensorSlicingConstructorAxis2<double>();
+    tensorSlicingConstructorAxis2<int>();
+}
+
+/* ---------------------------------------
+ * Tensor: Slicing constructor
+ * axis = 1 (columns)
+ * --------------------------------------- */
+
+template<typename T>
+void tensorSlicingConstructorAxis1() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    Tenzor<T> tenzSlice(tenz, 1, 1, 2); // matrices #0 and #1
+    EXPECT_EQ(2, tenzSlice.numRows());
+    EXPECT_EQ(2, tenzSlice.numCols());
+    EXPECT_EQ(1, tenzSlice.numMats());
+    std::vector<T> expected = {4, 5, 6, 7};
+    std::vector<T> tenzSliceDown(4);
+    tenzSlice.download(tenzSliceDown);
+    EXPECT_EQ(expected, tenzSliceDown);
+}
+
+TEST_F(TensorTest, tensorSlicingConstructorAxis1) {
+    tensorSlicingConstructorAxis1<float>();
+    tensorSlicingConstructorAxis1<double>();
+    tensorSlicingConstructorAxis1<int>();
+}
+
+/* ---------------------------------------
+ * Tensor: Slicing constructor
+ * axis = 0 (columns)
+ * --------------------------------------- */
+
+template<typename T>
+void tensorSlicingConstructorAxis0() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    Tenzor<T> tenzSlice(tenz, 0, 2, 3); // matrices #0 and #1
+    EXPECT_EQ(2, tenzSlice.numRows());
+    EXPECT_EQ(1, tenzSlice.numCols());
+    EXPECT_EQ(1, tenzSlice.numMats());
+    std::vector<T> expected = {3, 4};
+    std::vector<T> tenzSliceDown(2);
+    tenzSlice.download(tenzSliceDown);
+    EXPECT_EQ(expected, tenzSliceDown);
+}
+
+TEST_F(TensorTest, tensorSlicingConstructorAxis0) {
+    tensorSlicingConstructorAxis0<float>();
+    tensorSlicingConstructorAxis0<double>();
+    tensorSlicingConstructorAxis0<int>();
+}
+
+/* ---------------------------------------
+ * Tensor: Upload data
+ * --------------------------------------- */
+
+template<typename T>
+void tensorUpload() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(2, 3, 4);
+    tenz.upload(data);
+    EXPECT_EQ(2, tenz.numRows());
+    EXPECT_EQ(3, tenz.numCols());
+    EXPECT_EQ(4, tenz.numMats());
+    EXPECT_EQ(2 * 3 * 4, tenz.numel());
+    EXPECT_EQ(4, tenz.numMats());
+    EXPECT_EQ(8, tenz(1, 2, 3));
+}
+
+TEST_F(TensorTest, tensorUpload) {
+    tensorUpload<float>();
+    tensorUpload<double>();
+    tensorUpload<int>();
+}
+
+/* ---------------------------------------
+ * Tensor: deviceCopyTo
+ * --------------------------------------- */
+
+template<typename T>
+void tensorDeviceCopyTo() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    Tenzor<T> other(2, 3, 5, true);
+    Tenzor<T> z(other, 2, 1, 4);
+    tenz.deviceCopyTo(z);
+    std::vector<T> expected = {0, 0, 0, 0, 0, 0,
+                               1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 10, 5, 4, 3, 2, 1, -1, 4, 3, 4, 3, 4, 8};
+    std::vector<T> actual(2 * 3 * 5);
+    other.download(actual);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(TensorTest, tensorDeviceCopyTo) {
+    tensorDeviceCopyTo<float>();
+    tensorDeviceCopyTo<double>();
+    tensorDeviceCopyTo<int>();
+}
+
+/* ---------------------------------------
+ * Tensor: Frobenius norm
+ * --------------------------------------- */
+
+template<typename T>
+void tensorNormF(T epsilon) {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    EXPECT_NEAR(26.153393661244042, tenz.normF(), epsilon); // from MATLAB
+}
+
+TEST_F(TensorTest, tensorNormF) {
+    tensorNormF<float>(1e-6);
+    tensorNormF<double>(1e-12);
+}
+
+/* ---------------------------------------
+ * Tensor operator() to access element
+ * e.g., t(2, 3, 4)
+ * --------------------------------------- */
+
+template<typename T>
+void tensorBracketOperator() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    EXPECT_EQ(1, tenz(0, 0, 0));
+    EXPECT_EQ(3, tenz(0, 1, 2));
+    EXPECT_EQ(8, tenz(1, 2, 3));
+}
+
+TEST_F(TensorTest, tensorBracketOperator) {
+    tensorBracketOperator<float>();
+    tensorBracketOperator<double>();
+    tensorBracketOperator<int>();
+}
+
+/* ---------------------------------------
+ * Tensor assignment operator
+ * --------------------------------------- */
+
+template<typename T>
+void tensorAssignmentOperator() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    Tenzor<T> other;
+    other = tenz;
+    EXPECT_EQ(tenz.raw(), other.raw());
+    EXPECT_EQ(2, other.numRows());
+    EXPECT_EQ(3, other.numCols());
+    EXPECT_EQ(4, other.numMats());
+}
+
+TEST_F(TensorTest, tensorAssignmentOperator) {
+    tensorAssignmentOperator<float>();
+    tensorAssignmentOperator<double>();
+    tensorAssignmentOperator<int>();
+}
+
+/* ---------------------------------------
+ * Tensor times-equals scalar
+ * --------------------------------------- */
+
+template<typename T>
+void tensorTimesEqualsScalar() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    std::vector<T> dataTimes3 = {3, 6, 9, 12, 15, 18, 21, 24, 27, 24, 21, 30, 15, 12, 9, 6, 3, -3, 12, 9, 12, 9, 12,
+                                 24};
+    Tenzor<T> tenz(data, 2, 3, 4);
+    tenz *= 3.0;
+    std::vector<T> actual;
+    tenz.download(actual);
+    EXPECT_EQ(dataTimes3, actual);
+}
+
+TEST_F(TensorTest, tensorTimesEqualsScalar) {
+    tensorTimesEqualsScalar<float>();
+    tensorTimesEqualsScalar<double>();
+}
+
+/* ---------------------------------------
+ * Tensor plus-equals tensor
+ * --------------------------------------- */
+
+template<typename T>
+void tensorPlusEqualsTensor() {
+    std::vector<T> dataA = TENSOR_DATA_234A;
+    std::vector<T> dataB = TENSOR_DATA_234B;
+    Tenzor<T> A(dataA, 2, 3, 4);
+    Tenzor<T> B(dataB, 2, 3, 4);
+    A += B;
+    std::vector<T> expected = TENSOR_DATA_234APB;
+    std::vector<T> actual;
+    A.download(actual);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(TensorTest, tensorPlusEqualsTensor) {
+    tensorPlusEqualsTensor<float>();
+    tensorPlusEqualsTensor<double>();
+}
+

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -4,6 +4,9 @@
 #define PRECISION 1e-6
 
 
+/* ================================================================================================
+ *  TENSOR<T> TESTS
+ * ================================================================================================ */
 class TensorTest : public testing::Test {
 protected:
     TensorTest() {}
@@ -220,6 +223,23 @@ TEST_F(TensorTest, tensorNormF) {
 }
 
 /* ---------------------------------------
+ * Tensor: sum of absolute value of
+ * all elements
+ * --------------------------------------- */
+
+template<typename T>
+void tensorSumAbs() {
+    std::vector<T> data = TENSOR_DATA_234A;
+    Tenzor<T> tenz(data, 2, 3, 4);
+    EXPECT_NEAR(112, tenz.sumAbs(), PRECISION); // from MATLAB
+}
+
+TEST_F(TensorTest, tensorNormFtensorSumAbs) {
+    tensorSumAbs<float>();
+    tensorSumAbs<double>();
+}
+
+/* ---------------------------------------
  * Tensor operator() to access element
  * e.g., t(2, 3, 4)
  * --------------------------------------- */
@@ -421,6 +441,20 @@ TEST_F(TensorTest, tensorAddAB) {
     tensorAddAB<float>();
 }
 
+/* ================================================================================================
+ *  LEAST SQUARES TESTS
+ * ================================================================================================ */
+class LeastSquaresTest : public testing::Test {
+protected:
+    LeastSquaresTest() {}
+
+    virtual ~LeastSquaresTest() {}
+};
+
+/* ---------------------------------------
+ * Tensor: Least squares
+ * --------------------------------------- */
+
 template<typename T>
 void tensorLeastSquares1(T epsilon) {
     // TODO test with tall matrices too
@@ -443,7 +477,52 @@ void tensorLeastSquares1(T epsilon) {
     EXPECT_LT(nrmErr, epsilon);
 }
 
-TEST_F(TensorTest, tensorLS1) {
+TEST_F(LeastSquaresTest, tensorLS1) {
     tensorLeastSquares1<double>(1e-12);
     tensorLeastSquares1<float>(1e-4);
+}
+
+
+/* ================================================================================================
+ *  SVD TESTS
+ * ================================================================================================ */
+class SvdTest : public testing::Test {
+protected:
+    SvdTest() {}
+
+    virtual ~SvdTest() {}
+};
+
+
+/* ---------------------------------------
+ * Tensor: Least squares
+ * --------------------------------------- */
+
+/* ---------------------------------------
+ * Computation of singular values
+ * and matrix rank
+ * --------------------------------------- */
+
+template<typename T>
+requires std::floating_point<T>
+void singularValuesComputation(float epsilon) {
+    std::vector<T> bData{1, 6, 6, 6, 6, 6, 6, 6,
+                         2, 7, 7, 7, 7, 7, 7, 7,
+                         3, 8, 8, 8, 8, 8, 8, 8,};
+    Tenzor<T> B(bData, 8, 3);
+    Svd<T> svd(B, true, false);
+    EXPECT_EQ(0, svd.factorise());
+    auto S = svd.singularValues();
+    unsigned int r = svd.rank();
+    EXPECT_EQ(2, r);
+    EXPECT_NEAR(32.496241123753592, S(0), epsilon); // value from MATLAB
+    EXPECT_NEAR(0.997152358903242, S(1), epsilon); // value from MATLAB
+
+    auto U = svd.leftSingularVectors();
+    EXPECT_TRUE(U.has_value());
+}
+
+TEST_F(SvdTest, singularValuesComputation) {
+    singularValuesComputation<float>(1e-4);
+    singularValuesComputation<double>(1e-7);
 }

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -25,7 +25,7 @@ protected:
 
 template<typename T>
 void tensorConstructionZero() {
-    Tenzor<T> zero(2, 3, 4, true);
+    DTensor<T> zero(2, 3, 4, true);
     EXPECT_EQ(2, zero.numRows());
     EXPECT_EQ(3, zero.numCols());
     EXPECT_EQ(4, zero.numMats());
@@ -49,7 +49,7 @@ TEST_F(TensorTest, tensorConstructionZero) {
 template<typename T>
 void tensorConstructionFromVector() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     EXPECT_EQ(2, tenz.numRows());
     EXPECT_EQ(3, tenz.numCols());
     EXPECT_EQ(4, tenz.numMats());
@@ -69,8 +69,8 @@ TEST_F(TensorTest, tensorConstructionFromVector) {
 template<typename T>
 void tensorCopyConstructor() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
-    Tenzor<T> tenzCp(tenz);
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenzCp(tenz);
     EXPECT_EQ(2, tenzCp.numRows());
     EXPECT_EQ(3, tenzCp.numCols());
     EXPECT_EQ(4, tenzCp.numMats());
@@ -95,12 +95,12 @@ TEST_F(TensorTest, tensorCopyConstructor) {
 template<typename T>
 void tensorSlicingConstructorAxis2() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
-    Tenzor<T> tenzSlice(tenz, 2, 0, 1); // matrices #0 and #1
-    EXPECT_EQ(2, tenzSlice.numRows());
-    EXPECT_EQ(3, tenzSlice.numCols());
-    EXPECT_EQ(2, tenzSlice.numMats());
-    EXPECT_EQ(tenz.raw(), tenzSlice.raw()); // it is indeed a slice
+    DTensor<T> tens(data, 2, 3, 4);
+    DTensor<T> tensSlice(tens, 2, 0, 1); // matrices #0 and #1
+    EXPECT_EQ(2, tensSlice.numRows());
+    EXPECT_EQ(3, tensSlice.numCols());
+    EXPECT_EQ(2, tensSlice.numMats());
+    EXPECT_EQ(tens.raw(), tensSlice.raw()); // it is indeed a slice
 }
 
 TEST_F(TensorTest, tensorSlicingConstructorAxis2) {
@@ -117,8 +117,8 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis2) {
 template<typename T>
 void tensorSlicingConstructorAxis1() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
-    Tenzor<T> tenzSlice(tenz, 1, 1, 2); // matrices #0 and #1
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenzSlice(tenz, 1, 1, 2); // columns from 1 to 2
     EXPECT_EQ(2, tenzSlice.numRows());
     EXPECT_EQ(2, tenzSlice.numCols());
     EXPECT_EQ(1, tenzSlice.numMats());
@@ -142,8 +142,8 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis1) {
 template<typename T>
 void tensorSlicingConstructorAxis0() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
-    Tenzor<T> tenzSlice(tenz, 0, 2, 3); // matrices #0 and #1
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenzSlice(tenz, 0, 2, 3); // elements 2..3
     EXPECT_EQ(2, tenzSlice.numRows());
     EXPECT_EQ(1, tenzSlice.numCols());
     EXPECT_EQ(1, tenzSlice.numMats());
@@ -166,7 +166,7 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis0) {
 template<typename T>
 void tensorUpload() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(2, 3, 4);
+    DTensor<T> tenz(2, 3, 4);
     tenz.upload(data);
     EXPECT_EQ(2, tenz.numRows());
     EXPECT_EQ(3, tenz.numCols());
@@ -189,9 +189,9 @@ TEST_F(TensorTest, tensorUpload) {
 template<typename T>
 void tensorDeviceCopyTo() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
-    Tenzor<T> other(2, 3, 5, true);
-    Tenzor<T> z(other, 2, 1, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> other(2, 3, 5, true);
+    DTensor<T> z(other, 2, 1, 4);
     tenz.deviceCopyTo(z);
     std::vector<T> expected = {0, 0, 0, 0, 0, 0,
                                1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 10, 5, 4, 3, 2, 1, -1, 4, 3, 4, 3, 4, 8};
@@ -213,7 +213,7 @@ TEST_F(TensorTest, tensorDeviceCopyTo) {
 template<typename T>
 void tensorNormF(T epsilon) {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     EXPECT_NEAR(26.153393661244042, tenz.normF(), epsilon); // from MATLAB
 }
 
@@ -230,7 +230,7 @@ TEST_F(TensorTest, tensorNormF) {
 template<typename T>
 void tensorSumAbs() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     EXPECT_NEAR(112, tenz.sumAbs(), PRECISION); // from MATLAB
 }
 
@@ -247,7 +247,7 @@ TEST_F(TensorTest, tensorNormFtensorSumAbs) {
 template<typename T>
 void tensorBracketOperator() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     EXPECT_EQ(1, tenz(0, 0, 0));
     EXPECT_EQ(3, tenz(0, 1, 2));
     EXPECT_EQ(8, tenz(1, 2, 3));
@@ -266,8 +266,8 @@ TEST_F(TensorTest, tensorBracketOperator) {
 template<typename T>
 void tensorAssignmentOperator() {
     std::vector<T> data = TENSOR_DATA_234A;
-    Tenzor<T> tenz(data, 2, 3, 4);
-    Tenzor<T> other;
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> other;
     other = tenz;
     EXPECT_EQ(tenz.raw(), other.raw());
     EXPECT_EQ(2, other.numRows());
@@ -290,7 +290,7 @@ void tensorTimesEqualsScalar() {
     std::vector<T> data = TENSOR_DATA_234A;
     std::vector<T> dataTimes3 = {3, 6, 9, 12, 15, 18, 21, 24, 27, 24, 21, 30, 15, 12, 9, 6, 3, -3, 12, 9, 12, 9, 12,
                                  24};
-    Tenzor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     tenz *= 3.0;
     std::vector<T> actual;
     tenz.download(actual);
@@ -310,8 +310,8 @@ template<typename T>
 void tensorPlusEqualsTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    Tenzor<T> A(dataA, 2, 3, 4);
-    Tenzor<T> B(dataB, 2, 3, 4);
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T> B(dataB, 2, 3, 4);
     A += B;
     std::vector<T> expected = TENSOR_DATA_234APB;
     std::vector<T> actual;
@@ -332,8 +332,8 @@ template<typename T>
 void tensorMinusEqualsTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    Tenzor<T> A(dataA, 2, 3, 4);
-    Tenzor<T> B(dataB, 2, 3, 4);
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T> B(dataB, 2, 3, 4);
     A -= B;
     std::vector<T> expected = TENSOR_DATA_234AMB;
     std::vector<T> actual;
@@ -354,9 +354,9 @@ template<typename T>
 void tensorPlusTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    Tenzor<T> A(dataA, 2, 3, 4);
-    Tenzor<T> B(dataB, 2, 3, 4);
-    Tenzor<T> C = A + B;
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T> B(dataB, 2, 3, 4);
+    DTensor<T> C = A + B;
     std::vector<T> expected = TENSOR_DATA_234APB;
     std::vector<T> actual;
     C.download(actual);
@@ -376,9 +376,9 @@ template<typename T>
 void tensorMinusTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    Tenzor<T> A(dataA, 2, 3, 4);
-    Tenzor<T> B(dataB, 2, 3, 4);
-    Tenzor<T> C = A - B;
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T> B(dataB, 2, 3, 4);
+    DTensor<T> C = A - B;
     std::vector<T> expected = TENSOR_DATA_234AMB;
     std::vector<T> actual;
     C.download(actual);
@@ -397,8 +397,8 @@ TEST_F(TensorTest, tensorMinusTensor) {
 template<typename T>
 void tensorPointersToMatrices() {
     std::vector<T> dataA = TENSOR_DATA_234A;
-    Tenzor<T> A(dataA, 2, 3, 4);
-    Tenzor<T *> pointers = A.pointersToMatrices();
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T *> pointers = A.pointersToMatrices();
     EXPECT_EQ(4, pointers.numRows());
     EXPECT_EQ(1, pointers.numCols());
     EXPECT_EQ(1, pointers.numMats());
@@ -426,9 +426,9 @@ void tensorAddAB() {
     std::vector<T> bData = {6, 5, 4, 3, 2, 1,
                             7, 6, 5, 4, 3, 2,
                             1, 2, 1, 5, -6, 8};
-    Tenzor<T> A(aData, 2, 3, 3);
-    Tenzor<T> B(bData, 3, 2, 3);
-    Tenzor<T> C(2, 2, 3, true);
+    DTensor<T> A(aData, 2, 3, 3);
+    DTensor<T> B(bData, 3, 2, 3);
+    DTensor<T> C(2, 2, 3, true);
     C.addAB(A, B);
     std::vector<T> expected = {41, 56, 14, 20, 158, 176, 77, 86, 60, 64, 111, 118};
     std::vector<T> actual;
@@ -465,12 +465,12 @@ void tensorLeastSquares1(T epsilon) {
                             6, 8,
                             -9, 20};
     std::vector<T> bData = {1, 1, -1, 2, 30, -80};
-    Tenzor<T> A0(aData, 2, 2, 3);
-    Tenzor<T> A(A0);
-    Tenzor<T> B(bData, 2, 1, 3);
-    Tenzor<T> sol(B);
+    DTensor<T> A0(aData, 2, 2, 3);
+    DTensor<T> A(A0);
+    DTensor<T> B(bData, 2, 1, 3);
+    DTensor<T> sol(B);
     A0.leastSquares(sol);
-    Tenzor<T> C(2, 1, 3);
+    DTensor<T> C(2, 1, 3);
     C.addAB(A, sol);
     C -= B;
     T nrmErr = C.normF();
@@ -509,7 +509,7 @@ void singularValuesComputation(float epsilon) {
     std::vector<T> bData{1, 6, 6, 6, 6, 6, 6, 6,
                          2, 7, 7, 7, 7, 7, 7, 7,
                          3, 8, 8, 8, 8, 8, 8, 8,};
-    Tenzor<T> B(bData, 8, 3);
+    DTensor<T> B(bData, 8, 3);
     Svd<T> svd(B, true, false);
     EXPECT_EQ(0, svd.factorise());
     auto S = svd.singularValues();

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -418,6 +418,7 @@ void tensorAddAB() {
 
 TEST_F(TensorTest, tensorAddAB) {
     tensorAddAB<double>();
+    tensorAddAB<float>();
 }
 
 

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -14,6 +14,7 @@ protected:
 #define TENSOR_DATA_234A {1, 2,  3, 4, 5, 6, 7, 8, 9, 8, 7, 10, 5, 4, 3, 2, 1, -1, 4, 3, 4, 3, 4, 8}
 #define TENSOR_DATA_234B {7, -6, 9, 2, 1, 11, 34, -1, -4, -3, 12, 7, 9, 9, 2, 9, -9, -3, 2, 5, 4, -5, 4, 5}
 #define TENSOR_DATA_234APB {8, -4, 12, 6, 6, 17, 41, 7, 5, 5, 19, 17, 14, 13, 5, 11, -8, -4, 6, 8, 8, -2, 8, 13}
+#define TENSOR_DATA_234AMB {-6, 8, -6, 2, 4, -5, -27, 9, 13, 11, -5, 3, -4, -5, 1, -7, 10, 2, 2, -2, 0, 8, 0, 3};
 
 /* ---------------------------------------
  * Zero Tensor (Constructor)
@@ -301,5 +302,95 @@ void tensorPlusEqualsTensor() {
 TEST_F(TensorTest, tensorPlusEqualsTensor) {
     tensorPlusEqualsTensor<float>();
     tensorPlusEqualsTensor<double>();
+}
+
+/* ---------------------------------------
+ * Tensor minus-equals tensor
+ * --------------------------------------- */
+
+template<typename T>
+void tensorMinusEqualsTensor() {
+    std::vector<T> dataA = TENSOR_DATA_234A;
+    std::vector<T> dataB = TENSOR_DATA_234B;
+    Tenzor<T> A(dataA, 2, 3, 4);
+    Tenzor<T> B(dataB, 2, 3, 4);
+    A -= B;
+    std::vector<T> expected = TENSOR_DATA_234AMB;
+    std::vector<T> actual;
+    A.download(actual);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(TensorTest, tensorMinusEqualsTensor) {
+    tensorMinusEqualsTensor<float>();
+    tensorMinusEqualsTensor<double>();
+}
+
+/* ---------------------------------------
+ * Tensor + Tensor
+ * --------------------------------------- */
+
+template<typename T>
+void tensorPlusTensor() {
+    std::vector<T> dataA = TENSOR_DATA_234A;
+    std::vector<T> dataB = TENSOR_DATA_234B;
+    Tenzor<T> A(dataA, 2, 3, 4);
+    Tenzor<T> B(dataB, 2, 3, 4);
+    Tenzor<T>  C = A + B;
+    std::vector<T> expected = TENSOR_DATA_234APB;
+    std::vector<T> actual;
+    C.download(actual);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(TensorTest, tensorPlusTensor) {
+    tensorPlusTensor<float>();
+    tensorPlusTensor<double>();
+}
+
+/* ---------------------------------------
+ * Tensor - Tensor
+ * --------------------------------------- */
+
+template<typename T>
+void tensorMinusTensor() {
+    std::vector<T> dataA = TENSOR_DATA_234A;
+    std::vector<T> dataB = TENSOR_DATA_234B;
+    Tenzor<T> A(dataA, 2, 3, 4);
+    Tenzor<T> B(dataB, 2, 3, 4);
+    Tenzor<T>  C = A - B;
+    std::vector<T> expected = TENSOR_DATA_234AMB;
+    std::vector<T> actual;
+    C.download(actual);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(TensorTest, tensorMinusTensor) {
+    tensorMinusTensor<float>();
+    tensorMinusTensor<double>();
+}
+
+/* ---------------------------------------
+ * Tensor: pointers to matrices (on device)
+ * --------------------------------------- */
+
+template<typename T>
+void tensorPointersToMatrices() {
+    std::vector<T> dataA = TENSOR_DATA_234A;
+    Tenzor<T> A(dataA, 2, 3, 4);
+    Tenzor<T*> pointers = A.pointersToMatrices();
+    EXPECT_EQ(4, pointers.numRows());
+    EXPECT_EQ(1, pointers.numCols());
+    EXPECT_EQ(1, pointers.numMats());
+    T* p1 = pointers(1, 0, 0); // pointer to matrix #1
+    T hostDst; // let's see what's there...
+    cudaMemcpy(&hostDst, p1, sizeof(T), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(dataA[6], hostDst);
+}
+
+TEST_F(TensorTest, tensorPointersToMatrices) {
+    tensorPointersToMatrices<float>();
+    tensorPointersToMatrices<double>();
+    tensorPointersToMatrices<int>();
 }
 

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -582,6 +582,10 @@ void choleskyFactorisationSolution(T epsilon) {
     sol.download(actual);
     for (size_t i=0; i<3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);
 
+    DTensor<T> error = A * sol;
+    error -= rhs;
+    EXPECT_TRUE(error.normF() < epsilon);
+
 }
 
 TEST_F(CholeskyTest, choleskyFactorisationSolution) {

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -421,5 +421,29 @@ TEST_F(TensorTest, tensorAddAB) {
     tensorAddAB<float>();
 }
 
+template<typename T>
+void tensorLeastSquares1(T epsilon) {
+    // TODO test with tall matrices too
+    std::vector<T> aData = {1, 2,
+                            3, 4,
+                            7, 8,
+                            9, 10,
+                            6, 8,
+                            -9, 20};
+    std::vector<T> bData = {1, 1, -1, 2, 30, -80};
+    Tenzor<T> A0(aData, 2, 2, 3);
+    Tenzor<T> A(A0);
+    Tenzor<T> B(bData, 2, 1, 3);
+    Tenzor<T> sol(B);
+    A0.leastSquares(sol);
+    Tenzor<T> C(2, 1, 3);
+    C.addAB(A, sol);
+    C -= B;
+    T nrmErr = C.normF();
+    EXPECT_LT(nrmErr, epsilon);
+}
 
-
+TEST_F(TensorTest, tensorLS1) {
+    tensorLeastSquares1<double>(1e-12);
+    tensorLeastSquares1<float>(1e-4);
+}

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -336,7 +336,7 @@ void tensorPlusTensor() {
     std::vector<T> dataB = TENSOR_DATA_234B;
     Tenzor<T> A(dataA, 2, 3, 4);
     Tenzor<T> B(dataB, 2, 3, 4);
-    Tenzor<T>  C = A + B;
+    Tenzor<T> C = A + B;
     std::vector<T> expected = TENSOR_DATA_234APB;
     std::vector<T> actual;
     C.download(actual);
@@ -358,7 +358,7 @@ void tensorMinusTensor() {
     std::vector<T> dataB = TENSOR_DATA_234B;
     Tenzor<T> A(dataA, 2, 3, 4);
     Tenzor<T> B(dataB, 2, 3, 4);
-    Tenzor<T>  C = A - B;
+    Tenzor<T> C = A - B;
     std::vector<T> expected = TENSOR_DATA_234AMB;
     std::vector<T> actual;
     C.download(actual);
@@ -378,11 +378,11 @@ template<typename T>
 void tensorPointersToMatrices() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     Tenzor<T> A(dataA, 2, 3, 4);
-    Tenzor<T*> pointers = A.pointersToMatrices();
+    Tenzor<T *> pointers = A.pointersToMatrices();
     EXPECT_EQ(4, pointers.numRows());
     EXPECT_EQ(1, pointers.numCols());
     EXPECT_EQ(1, pointers.numMats());
-    T* p1 = pointers(1, 0, 0); // pointer to matrix #1
+    T *p1 = pointers(1, 0, 0); // pointer to matrix #1
     T hostDst; // let's see what's there...
     cudaMemcpy(&hostDst, p1, sizeof(T), cudaMemcpyDeviceToHost);
     EXPECT_EQ(dataA[6], hostDst);
@@ -393,4 +393,32 @@ TEST_F(TensorTest, tensorPointersToMatrices) {
     tensorPointersToMatrices<double>();
     tensorPointersToMatrices<int>();
 }
+
+/* ---------------------------------------
+ * Tensor: C = AB
+ * --------------------------------------- */
+
+template<typename T>
+void tensorAddAB() {
+    std::vector<T> aData = {1, 2, 3, 4, 5, 6,
+                            7, 8, 9, 10, 11, 12,
+                            13, 14, 15, 16, 17, 18};
+    std::vector<T> bData = {6, 5, 4, 3, 2, 1,
+                            7, 6, 5, 4, 3, 2,
+                            1, 2, 1, 5, -6, 8};
+    Tenzor<T> A(aData, 2, 3, 3);
+    Tenzor<T> B(bData, 3, 2, 3);
+    Tenzor<T> C(2, 2, 3, true);
+    C.addAB(A, B);
+    std::vector<T> expected = {41, 56, 14, 20, 158, 176, 77, 86, 60, 64, 111, 118};
+    std::vector<T> actual;
+    C.download(actual);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(TensorTest, tensorAddAB) {
+    tensorAddAB<double>();
+}
+
+
 


### PR DESCRIPTION
### Main idea

Instead of vectors, matrices, and tensors, everything is a tensor and all operations are defined on 3D tensors, $T=(T_1, T_2, \ldots, T_k)$, where $T_i\in\mathbb{R}^{m\times n}$. For exampe, $cT$, $T+T'$ and $T-T'$ are defined naturally. We also have the tensor-tensor product $TT' = (T_1T_1', \ldots, T_kT_k')$, which is performed by `cublas<t>gemmBatched`.

I have also implemented the least-squares method for tensors that allows us to do $T^\dagger B = (T_1^\dagger B_1, \ldots, T_k^\dagger B_k)$ (many least squares in parallel).

I implemented a "slicing" constructor for tensors that allows us to select matrices, columns and rows (T&C's apply of course).


### A few examples

I haven't written any proper API docs or human-readable documentation yet, but here are a few quick examples:

#### Slicing

Here we select matrices 0 and 1, so we obtain a (2,3,2)-ensor:

```c++
#define TENSOR_DATA_234A {1, 2,  3, 4, 5, 6, 7, 8, 9, 8, 7, 10, 5, 4, 3, 2, 1, -1, 4, 3, 4, 3, 4, 8}

std::vector<T> data = TENSOR_DATA_234A;
DTensor<T> tens(data, 2, 3, 4); // tensor 2 x 3 x 4
DTensor<T> tensSlice(tens, 2, 0, 1); // matrices #0 and #1
```

Here we select the columns 1 and 2 only, and we obtain a (2,2,1)-tensor

```c++
DTensor<T> tenzSlice(tens, 1, 1, 2); // columns from 1 to 2
```

We can also slice to obtain a vector of elements as follows; here the result is a (2, 1, 1)-tensor:

```c++
DTensor<T> tensSliceVec(tenz, 0, 2, 3); // elements 2..3
```


#### Uploading, downloading, d2d copying

Like this:

```c++
DTensor<T> tens(2, 3, 4);
tens.upload(data);
```

and 

```c++
DTensor<T> tens(data, 2, 3, 4);
DTensor<T> other(2, 3, 5, true); // true: zero tensor
DTensor<T> z(other, 2, 1, 4); // slicing
tens.deviceCopyTo(z);
```

#### Norms

The Frobenius norm of a tensor (the Euclidean norm when it is a vector) is `.normF()`. The sum of absolute values of all elements is `.sumAbs()`.


#### Printing

Simple as:

```c++
std::cout << tens;
```

#### Accessing individual elements

This is only for debugging purposes because it moves data from the device to the host:

```c++
double element1 = tens(2, 1, 0);
double element2 = tens(2, 1); // equivalent
```


#### Some operators 

The operator `*=` is implemented for scalar multiplication (e.g, `t *= 3.0`). The operators `+=`, `-=`, `+`, and `-` have been implemented. Here is an example of using `addAB`:

```c++
std::vector<T> aData = {1, 2, 3, 4, 5, 6,
                            7, 8, 9, 10, 11, 12,
                            13, 14, 15, 16, 17, 18};
std::vector<T> bData = {6, 5, 4, 3, 2, 1,
                        7, 6, 5, 4, 3, 2,
                        1, 2, 1, 5, -6, 8};
DTensor<T> A(aData, 2, 3, 3);
DTensor<T> B(bData, 3, 2, 3);
DTensor<T> C(2, 2, 3, true);
C.addAB(A, B);  // C <- AB
```

Operator `*` has also been implemented for tensor-tensor multiplication (but `addAB` might often be more a appropriate choice).

#### Least squares

Here is a quick example

```c++
std::vector<T> aData = {1, 2,
                            3, 4,
                            7, 8,
                            9, 10,
                            6, 8,
                            -9, 20};
std::vector<T> bData = {1, 1, -1, 2, 30, -80};
DTensor<T> A0(aData, 2, 2, 3);
DTensor<T> A(A0);
DTensor<T> B(bData, 2, 1, 3);
DTensor<T> sol(B);
A0.leastSquares(sol);
DTensor<T> C(2, 1, 3);
C.addAB(A, sol);
C -= B;
T nrmErr = C.normF();
```


#### Singular value decomposition

It is currently supported for *matrices* only, i.e., (m, n, 1)-tensors, although we can easily loop and do multiple SVDs. Currently, cusolver doesn't support batched SVD, but we could use [kblas](https://github.com/ecrc/kblas-gpu?tab=readme-ov-file) if necessary. Here's a little example:


```c++
std::vector<T> bData{ 1, 6, 6, 6, 6, 6, 6, 6,
                       2, 7, 7, 7, 7, 7, 7, 7,
                       3, 8, 8, 8, 8, 8, 8, 8,};
DTensor<T> B(bData, 8, 3);
Svd<T> svd(B, true, false);
EXPECT_EQ(0, svd.factorise());
auto S = svd.singularValues();
unsigned int r = svd.rank();
``` 

#### Cholesky decomposition 

Not implemented yet

### TODOs

- [x] Cholesky factoriser and solver
- [ ] Transpose of tensor (i.e., transpose of each matrix)
- [ ] Nullspace matrix and 
- [ ] Update `README.md`
- [ ] API docs

**Note:** In this implementation I assumed that the user provides the data in column-major format. I guess we can keep the transformation from row-major to column-major outside `DTensor`.


