### PR TITLE
Function gpuErrChk works in c++17

### DIFF
--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -7,7 +7,6 @@
 #include <stdexcept>
 #include <memory>
 #include <optional>
-#include <source_location>
 #include <cassert>
 
 #ifndef TENSOR_CUH
@@ -16,45 +15,43 @@
 /**
  * Define defaults
  */
-
-#define TENSOR_DEFAULT_TYPE double
+#define DEFAULT_FPX double
 #define THREADS_PER_BLOCK 512
 #define DIM2BLOCKS(n) ((n) / THREADS_PER_BLOCK + ((n) % THREADS_PER_BLOCK != 0))
 #if (__cplusplus >= 201703L)  ///< if c++17 or above
-#define TENSOR_TEMPLATE_WITH_TYPE template<typename T = TENSOR_DEFAULT_TYPE>
+#define TEMPLATE_WITH_TYPE_T template<typename T = DEFAULT_FPX>
 #else
-#define TENSOR_TEMPLATE_WITH_TYPE template<typename T>
+#define TEMPLATE_WITH_TYPE_T template<typename T>
 #endif
 #if (__cplusplus >= 202002L)  ///< if c++20 or above
-#define TENSOR_REQUIRES_TYPE requires std::floating_point<T>
+#define TEMPLATE_CONSTRAINT_REQUIRES_FPX requires std::floating_point<T>
 #else
-#define TENSOR_REQUIRES_TYPE
+#define TEMPLATE_CONSTRAINT_REQUIRES_FPX
 #endif
 
 /**
  * Check for errors when calling GPU functions
  */
-#define gpuErrChk(status) { gpuAssert((status), std::source_location::current()); }
+#define gpuErrChk(status) { gpuAssert((status), __FILE__, __LINE__); } while(false)
 
-TENSOR_TEMPLATE_WITH_TYPE
-inline void gpuAssert(T code, std::source_location loc, bool abort = true) {
+TEMPLATE_WITH_TYPE_T inline void gpuAssert(T code, const char *file, int line, bool abort = true) {
     if constexpr (std::is_same_v<T, cudaError_t>) {
         if (code != cudaSuccess) {
             std::cerr << "cuda error. String: " << cudaGetErrorString(code)
-                      << ", file: " << loc.file_name() << ", line: " << loc.line() << "\n";
+                      << ", file: " << file << ", line: " << line << "\n";
             if (abort) exit(code);
         }
     } else if constexpr (std::is_same_v<T, cublasStatus_t>) {
         if (code != CUBLAS_STATUS_SUCCESS) {
             std::cerr << "cublas error. Name: " << cublasGetStatusName(code)
                       << ", string: " << cublasGetStatusString(code)
-                      << ", file: " << loc.file_name() << ", line: " << loc.line() << "\n";
+                      << ", file: " << file << ", line: " << line << "\n";
             if (abort) exit(code);
         }
     } else if constexpr (std::is_same_v<T, cusolverStatus_t>) {
         if (code != CUSOLVER_STATUS_SUCCESS) {
             std::cerr << "cusolver error. Status: " << code
-                      << ", file: " << loc.file_name() << ", line: " << loc.line() << "\n";
+                      << ", file: " << file << ", line: " << line << "\n";
             if (abort) exit(code);
         }
     } else {
@@ -129,7 +126,7 @@ enum StorageMode {
  * Tensors can be used to do a batched operation on many similar-sized matrices or vectors in parallel.
  * @tparam T type of data stored in tensor
  */
-TENSOR_TEMPLATE_WITH_TYPE
+TEMPLATE_WITH_TYPE_T
 class DTensor {
 
 private:
@@ -866,7 +863,7 @@ std::ostream &DTensor<T>::print(std::ostream &out) const {
  * @param d_count on exit, count of elements (int on device)
  * @param epsilon threshold
  */
-TENSOR_TEMPLATE_WITH_TYPE TENSOR_REQUIRES_TYPE
+TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 __global__ void k_countNonzeroSingularValues(const T *d_array, size_t n, unsigned int *d_count, T epsilon) {
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
     if (idx < n && d_array[idx] > epsilon) {
@@ -880,7 +877,7 @@ __global__ void k_countNonzeroSingularValues(const T *d_array, size_t n, unsigne
  * Then, many same-type-(m,n,1)-tensor can be factorised using this object's workspace.
  * @tparam T data type of (m,n,1)-tensor to be factorised (must be float or double)
  */
-TENSOR_TEMPLATE_WITH_TYPE TENSOR_REQUIRES_TYPE
+TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 class Svd {
 
 private:
@@ -1081,7 +1078,7 @@ inline bool Svd<float>::factorise() {
  * Then, many same-type-(m,n,1)-tensor can be factorised using this object's workspace
  * @tparam T data type of (m,n,1)-tensor to be factorised (must be float or double)
  */
-TENSOR_TEMPLATE_WITH_TYPE TENSOR_REQUIRES_TYPE
+TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 class CholeskyFactoriser {
 
 private:
@@ -1198,7 +1195,7 @@ inline int CholeskyFactoriser<float>::solve(DTensor<float> &rhs) {
  * Nullspace computes, pads, and stores the nullspace matrices.
  * @tparam T data type (must be float or double)
  */
-TENSOR_TEMPLATE_WITH_TYPE TENSOR_REQUIRES_TYPE
+TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 class Nullspace {
 
 private:
@@ -1236,7 +1233,8 @@ public:
 };
 
 
-template<typename T> TENSOR_REQUIRES_TYPE
+template<typename T>
+TEMPLATE_CONSTRAINT_REQUIRES_FPX
 inline Nullspace<T>::Nullspace(DTensor<T> &a) {
     size_t m = a.numRows(), n = a.numCols(), nMats = a.numMats();
     if (m > n) throw std::invalid_argument("I was expecting a square or fat matrix");
@@ -1271,7 +1269,8 @@ inline Nullspace<T>::Nullspace(DTensor<T> &a) {
     }
 }
 
-template<typename T> TENSOR_REQUIRES_TYPE
+template<typename T>
+TEMPLATE_CONSTRAINT_REQUIRES_FPX
 inline void Nullspace<T>::project(DTensor<T> &b) {
     b.addAB(*m_projOp, b, 1, 0);
 }


### PR DESCRIPTION
## Main Changes

- Function `gpuErrChk` works in C++17 (`std::source_location` was removed)
- Renamed some of the `#define`s

