### PR TITLE
fix column slicing constructor

### DIFF
--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -515,7 +515,7 @@ DTensor<T>::DTensor(const DTensor<T> &other, size_t axis, size_t from, size_t to
         m_numCols = other.m_numCols;
         m_numMats = len;
     } else if (axis == 1) {
-        offset = other.m_numCols * from;
+        offset = other.m_numRows * from;
         m_numRows = other.m_numRows;
         m_numCols = len;
         m_numMats = 1;

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -215,7 +215,7 @@ void tensorSlicingConstructorAxis1() {
     EXPECT_EQ(2, tenzSlice.numRows());
     EXPECT_EQ(2, tenzSlice.numCols());
     EXPECT_EQ(1, tenzSlice.numMats());
-    std::vector<T> expected = {4, 5, 6, 7};
+    std::vector<T> expected = {3, 4, 5, 6};
     std::vector<T> tenzSliceDown(4);
     tenzSlice.download(tenzSliceDown);
     EXPECT_EQ(expected, tenzSliceDown);


### PR DESCRIPTION
Fixing the column slice constructor from another `DTensor`.

The following now works correctly
```c++
size_t nRow = 10;
size_t nCol = 2;
DTensor<real_t> d_mat(nRow, nCol);
DTensor<real_t> d_col1(d_mat, 1, 0, 0);
DTensor<real_t> d_col2(d_mat, 1, 1, 1);
std::vector<real_t> col(nRow);
std::iota (std::begin(col), std::end(col), 0);
d_col1.upload(col);
d_col2.upload(col);
std::cout << "col 1:\n" << d_col1;
std::cout << "col 2:\n" << d_col2;
std::cout << "mat :\n" << d_mat;
```