### PR TITLE
Givens rotations and Givens annihilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ---------------------
       v1.3.0
      --------------------- -->
-## v1.3.0-alpha.1 
+## v1.3.0 - 11-10-2024 
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ---------------------
       v1.3.0
      --------------------- -->
-## v1.3.0 - Unreleased
+## v1.3.0-alpha.1 
 
 ### Added
 
 - Left/right Givens rotations
+- `GivensAnnihilator` implemented
 
 
 <!-- ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 <!-- ---------------------
+      v1.3.0
+     --------------------- -->
+## v1.3.0 - Unreleased
+
+### Added
+
+- Left/right Givens rotations
+
+
+<!-- ---------------------
       v1.2.1
      --------------------- -->
 ## v1.2.1 - 07-10-2024

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -732,16 +732,19 @@ void DTensor<float>::applyRightGivensRotation(size_t i, size_t j, float c, float
 
 template<typename T>
 void DTensor<T>::applyLeftGivensRotation(size_t i, size_t j, T c, T s) {
+    if (m_numMats > 1 ) throw std::invalid_argument("[applyLeftGivensRotation] tensors (nMat>1) not supported");
     if constexpr (std::is_same_v<T, double>) {
+        double minus_s = -s;
         gpuErrChk(cublasDrot(Session::getInstance().cuBlasHandle(), m_numCols,
                              m_d_data + i, m_numRows,
                              m_d_data + j, m_numRows,
-                             &c, &s) );
+                             &c, &minus_s) );
     } else if constexpr (std::is_same_v<T, float>) {
+        float minus_s = -s;
         gpuErrChk(cublasSrot(Session::getInstance().cuBlasHandle(), m_numCols,
                              m_d_data + i, m_numRows,
                              m_d_data + j, m_numRows,
-                             &c, &s) );
+                             &c, &minus_s) );
     } else {
         throw std::invalid_argument("[applyLeftGivensRotation] Unsupported type T");
     }

--- a/main.cu
+++ b/main.cu
@@ -19,12 +19,10 @@ int main() {
     v.reserve(m*n);
     std::iota(v.begin(), v.end(), 1);
 
-    auto a = DTensor<double>(v, m, n, 1);
-    auto b = DTensor<double>(a);
-    size_t i_givens = 1, j_givens = 9;
-    double c = 0.1;
-    double s = 0.9;
-    a.applyLeftGivensRotation(i_givens, j_givens, c, s);
+    DTensor<double> a = DTensor<double>(v, m, n, 1);
+
+    auto ga = GivensAnnihilator<double>(a);
+    ga.annihilate(1,2,4);
 
     std::cout << a;
 

--- a/main.cu
+++ b/main.cu
@@ -21,10 +21,10 @@ int main() {
 
     auto a = DTensor<double>(v, m, n, 1);
     auto b = DTensor<double>(a);
-    size_t i_givens = 1, j_givens = 4;
+    size_t i_givens = 1, j_givens = 9;
     double c = 0.1;
     double s = 0.9;
-    a.applyRightGivensRotation(i_givens, j_givens, c, s);
+    a.applyLeftGivensRotation(i_givens, j_givens, c, s);
 
     std::cout << a;
 

--- a/main.cu
+++ b/main.cu
@@ -12,18 +12,13 @@
 
 
 int main() {
-//    cudaStream_t stream1;
-//    cudaStreamCreate(&stream1);
-//    cublasSetStream(Session::getInstance().cuBlasHandle(), stream1);
 
-    cudaStream_t s1;
-    cudaStreamCreate(&s1);
+    auto a = DTensor<double>::createRandomTensor(10, 6, 1, -2, 2);
+    auto b = DTensor<double>(a);
+    a.applyRightGivensRotation(2, 4, 0.5, 0.5);
 
-    auto a = DTensor<float>::createRandomTensor(2000, 200, 1, -2, 2);
-    Svd svd(a);
-    svd.factorise();
-
-    std::cout << svd.singularValues();
+    auto c = a - b;
+    std::cout << c;
 
 
     return 0;

--- a/main.cu
+++ b/main.cu
@@ -18,11 +18,10 @@ int main() {
     std::vector<double> v(m*n);
     v.reserve(m*n);
     std::iota(v.begin(), v.end(), 1);
-
-    DTensor<double> a = DTensor<double>(v, m, n, 1);
+    DTensor<double> a = DTensor<double>(v, m, n);
 
     auto ga = GivensAnnihilator<double>(a);
-    ga.annihilate(1,2,4);
+    ga.annihilate(0, 1, 2);
 
     std::cout << a;
 

--- a/main.cu
+++ b/main.cu
@@ -13,12 +13,20 @@
 
 int main() {
 
-    auto a = DTensor<double>::createRandomTensor(10, 6, 1, -2, 2);
-    auto b = DTensor<double>(a);
-    a.applyRightGivensRotation(2, 4, 0.5, 0.5);
+    size_t m = 10;
+    size_t n = 6;
+    std::vector<double> v(m*n);
+    v.reserve(m*n);
+    std::iota(v.begin(), v.end(), 1);
 
-    auto c = a - b;
-    std::cout << c;
+    auto a = DTensor<double>(v, m, n, 1);
+    auto b = DTensor<double>(a);
+    size_t i_givens = 1, j_givens = 4;
+    double c = 0.1;
+    double s = 0.9;
+    a.applyRightGivensRotation(i_givens, j_givens, c, s);
+
+    std::cout << a;
 
 
     return 0;

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -1359,8 +1359,8 @@ TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void givensAnnihilateElement(T epsilon) {
     size_t m = 10;
     size_t n = 6;
-    std::vector<double> v(m*n);
-    v.reserve(m*n);
+    std::vector<double> v(m * n);
+    v.reserve(m * n);
     std::iota(v.begin(), v.end(), 1);
 
     DTensor<double> a = DTensor<double>(v, m, n, 1);
@@ -1368,7 +1368,7 @@ void givensAnnihilateElement(T epsilon) {
     auto ga = GivensAnnihilator<double>(a);
     size_t i = 0;
     for (size_t k = 1; k < m; k++) {
-        for (size_t j=0; j<n; j++) {
+        for (size_t j = 0; j < n; j++) {
             ga.annihilate(i, k, j);
             EXPECT_NEAR(0.0, a(k, j), epsilon);
         }
@@ -1379,3 +1379,35 @@ TEST_F(GivensAnnihilatorTest, givensAnnihilateElement) {
     givensAnnihilateElement<double>(1e-14);
     givensAnnihilateElement<float>(1e-12);
 }
+
+
+
+/* ---------------------------------------
+ * GivensAnnihilator: correctness
+ * --------------------------------------- */
+
+TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
+void givensAnnihilateCorrectness(T epsilon) {
+    size_t m = 10, n = 6;
+    std::vector<double> v(m * n);
+    v.reserve(m * n);
+    std::iota(v.begin(), v.end(), 1);
+    DTensor<double> a = DTensor<double>(v, m, n);
+
+    auto ga = GivensAnnihilator<double>(a);
+    ga.annihilate(0, 1, 2);
+
+    EXPECT_NEAR(0.0, a(1, 2), epsilon);
+    EXPECT_NEAR(2.137186834969645, a(0, 0), epsilon);
+    EXPECT_NEAR(44.552125559751822, a(0, 3), epsilon);
+    EXPECT_NEAR(-0.328797974610715, a(1, 3), epsilon);
+
+}
+
+TEST_F(GivensAnnihilatorTest, givensAnnihilateCorrectness) {
+    givensAnnihilateCorrectness<double>(1e-14);
+    givensAnnihilateCorrectness<float>(1e-12);
+}
+
+
+

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -400,15 +400,15 @@ void tensorRightGivens(T epsilon) {
     // Construct matrix A
     size_t m = 10;
     size_t n = 6;
-    std::vector<double> v(m * n);
+    std::vector<T> v(m * n);
     v.reserve(m * n);
     std::iota(v.begin(), v.end(), 1);
-    auto a = DTensor<double>(v, m, n, 1);
+    auto a = DTensor<T>(v, m, n, 1);
 
     // Apply right Givens rotation G
     size_t i_givens = 1, j_givens = 4;
-    double c = 0.1;
-    double minus_s = sqrt(1 - c * c);
+    T c = 0.1;
+    T minus_s = sqrt(1 - c * c);
     a.applyRightGivensRotation(i_givens, j_givens, &c, &minus_s);
 
     // Check the result
@@ -422,8 +422,8 @@ void tensorRightGivens(T epsilon) {
 }
 
 TEST_F(TensorTest, tensorRightGivens) {
-    tensorRightGivens<float>(1e-10);
-    tensorRightGivens<double>(1e-14);
+    tensorRightGivens<float>(PRECISION_LOW);
+    tensorRightGivens<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1359,13 +1359,12 @@ TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void givensAnnihilateElement(T epsilon) {
     size_t m = 10;
     size_t n = 6;
-    std::vector<double> v(m * n);
+    std::vector<T> v(m * n);
     v.reserve(m * n);
     std::iota(v.begin(), v.end(), 1);
 
-    DTensor<double> a = DTensor<double>(v, m, n, 1);
-
-    auto ga = GivensAnnihilator<double>(a);
+    auto a = DTensor<T>(v, m, n, 1);
+    auto ga = GivensAnnihilator<T>(a);
     size_t i = 0;
     for (size_t k = 1; k < m; k++) {
         for (size_t j = 0; j < n; j++) {
@@ -1376,8 +1375,8 @@ void givensAnnihilateElement(T epsilon) {
 }
 
 TEST_F(GivensAnnihilatorTest, givensAnnihilateElement) {
-    givensAnnihilateElement<double>(1e-14);
-    givensAnnihilateElement<float>(1e-12);
+    givensAnnihilateElement<float>(PRECISION_LOW);
+    givensAnnihilateElement<double>(PRECISION_HIGH);
 }
 
 

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -392,6 +392,41 @@ TEST_F(TensorTest, tensorMin) {
 }
 
 /* ---------------------------------------
+ * Tensor: right Givens rotation
+ * --------------------------------------- */
+
+TEMPLATE_WITH_TYPE_T
+void tensorRightGivens(T epsilon) {
+    // Construct matrix A
+    size_t m = 10;
+    size_t n = 6;
+    std::vector<double> v(m*n);
+    v.reserve(m*n);
+    std::iota(v.begin(), v.end(), 1);
+    auto a = DTensor<double>(v, m, n, 1);
+
+    // Apply right Givens rotation G
+    size_t i_givens = 1, j_givens = 4;
+    double c = 0.1;
+    double s = sqrt(1 - c*c);
+    a.applyRightGivensRotation(i_givens, j_givens, c, s);
+
+    // Check the result
+    for (size_t i=0;i<m; i++) {
+        EXPECT_NEAR(1 + i, a(i, 0), epsilon);
+        EXPECT_NEAR(21 + i, a(i, 2), epsilon);
+        EXPECT_NEAR(31 + i, a(i, 3), epsilon);
+        EXPECT_NEAR((11+i)*c - (41+i)*s, a(i, i_givens), epsilon);
+        EXPECT_NEAR((11+i)*s + (41+i)*c, a(i, j_givens), epsilon);
+    }
+}
+
+TEST_F(TensorTest, tensorRightGivens) {
+    tensorRightGivens<float>(1e-10);
+    tensorRightGivens<double>(1e-12);
+}
+
+/* ---------------------------------------
  * Tensor operator() to access element
  * e.g., t(2, 3, 4)
  * --------------------------------------- */

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -400,30 +400,67 @@ void tensorRightGivens(T epsilon) {
     // Construct matrix A
     size_t m = 10;
     size_t n = 6;
-    std::vector<double> v(m*n);
-    v.reserve(m*n);
+    std::vector<double> v(m * n);
+    v.reserve(m * n);
     std::iota(v.begin(), v.end(), 1);
     auto a = DTensor<double>(v, m, n, 1);
 
     // Apply right Givens rotation G
     size_t i_givens = 1, j_givens = 4;
     double c = 0.1;
-    double s = sqrt(1 - c*c);
+    double s = sqrt(1 - c * c);
     a.applyRightGivensRotation(i_givens, j_givens, c, s);
 
     // Check the result
-    for (size_t i=0;i<m; i++) {
+    for (size_t i = 0; i < m; i++) {
         EXPECT_NEAR(1 + i, a(i, 0), epsilon);
         EXPECT_NEAR(21 + i, a(i, 2), epsilon);
         EXPECT_NEAR(31 + i, a(i, 3), epsilon);
-        EXPECT_NEAR((11+i)*c - (41+i)*s, a(i, i_givens), epsilon);
-        EXPECT_NEAR((11+i)*s + (41+i)*c, a(i, j_givens), epsilon);
+        EXPECT_NEAR((11 + i) * c - (41 + i) * s, a(i, i_givens), epsilon);
+        EXPECT_NEAR((11 + i) * s + (41 + i) * c, a(i, j_givens), epsilon);
     }
 }
 
 TEST_F(TensorTest, tensorRightGivens) {
     tensorRightGivens<float>(1e-10);
-    tensorRightGivens<double>(1e-12);
+    tensorRightGivens<double>(1e-14);
+}
+
+/* ---------------------------------------
+ * Tensor: left Givens rotation
+ * --------------------------------------- */
+
+TEMPLATE_WITH_TYPE_T
+void tensorLeftGivens(T epsilon) {
+    // Construct matrix A
+    size_t m = 10;
+    size_t n = 6;
+    std::vector<double> v(m * n);
+    v.reserve(m * n);
+    std::iota(v.begin(), v.end(), 1);
+    auto a = DTensor<double>(v, m, n, 1);
+
+    // Apply right Givens rotation G
+    size_t i_givens = 1, j_givens = 9;
+    double c = 0.1;
+    double s = sqrt(1 - c * c);
+    a.applyLeftGivensRotation(i_givens, j_givens, c, s);
+
+    std::cout << a;
+    // Check the result
+    for (size_t j = 0; j < n; j++) {
+        EXPECT_NEAR(1 + 10 * j, a(0, j), epsilon);
+        for (size_t i = 2; i < m - 1; i++) {
+            EXPECT_NEAR(1 + i + 10 * j, a(i, j), epsilon);
+        }
+        EXPECT_NEAR((2 + 10 * j) * c - (10 + 10 * j) * s, a(i_givens, j), epsilon);
+        EXPECT_NEAR((2 + 10 * j) * s + (10 + 10 * j) * c, a(j_givens, j), epsilon);
+    }
+}
+
+TEST_F(TensorTest, tensorLeftGivens) {
+    tensorLeftGivens<float>(1e-10);
+    tensorLeftGivens<double>(1e-14);
 }
 
 /* ---------------------------------------
@@ -1154,14 +1191,14 @@ void qrLeastSquares(T epsilon) {
     size_t nR = 4;
     size_t nC = 3;
     DTensor<T> temp(nR, nC);
-    std::vector<T> vecA = { 85.5638, -59.4001, -80.1992,
-                            99.9464, 5.51393, 5.17935,
-                            6.87488, -26.7536, 36.0914,
-                            -44.3857, -32.1268, 54.8915 };  // Random matrix
-    std::vector<T> vecB = { -23.3585,
-                            -48.5744,
-                            43.4229,
-                            -56.5081 };  // Random vector
+    std::vector<T> vecA = {85.5638, -59.4001, -80.1992,
+                           99.9464, 5.51393, 5.17935,
+                           6.87488, -26.7536, 36.0914,
+                           -44.3857, -32.1268, 54.8915};  // Random matrix
+    std::vector<T> vecB = {-23.3585,
+                           -48.5744,
+                           43.4229,
+                           -56.5081};  // Random vector
     DTensor<T> A(vecA, nR, nC, 1, rowMajor);
     DTensor<T> b(vecB, nR);
     DTensor<T> xFull(nR);


### PR DESCRIPTION
## Main Changes

Implementation of left/right Givens rotations

The following methods have been implemented:

```c++
void applyLeftGivensRotation(size_t i, size_t j, const T *c, const T *minus_s);
void applyRightGivensRotation(size_t i, size_t j, const T *c, const T *minus_s);
```

where note that we need to provide a pointer to `minus_s`. 

The new class `GivensAnnihilator` is introduced; this had to be a class rather than a method in `DTesnsor` because it needs to allocate a bit of memory (three numbers) - namely, $a$, $c$, and $s$. These are stored directly on the device.

> [!IMPORTANT] 
> When calling `applyLeftGivensRotation` if we want to pass device pointers for `c` and `minus_s` we need to first call 
> ```c++
> gpuErrChk(cublasSetPointerMode(Session::getInstance().cuBlasHandle(), CUBLAS_POINTER_MODE_DEVICE));
> ```

**Not supported:** Batch-mode Givens on multiple matrices (packed in a tensor); an exception will be thrown

## TODO 

- [x] Test `GivensAnnihilator::annihilate` more thoroughly
- [x] API docs
- [x] Update changelog


## Associated Issues

- Closes #46
