### PR TITLE
Memory management improvements

### DIFF
--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -185,6 +185,7 @@ private:
     size_t m_numCols = 0;  ///< Number of columns
     size_t m_numMats = 0;  ///< Number of matrices
     bool m_doDestroy = false;  ///< Whether to destroy memory
+    T** m_rawPtrToMatrices; ///< raw pointers to matrices
 
     bool destroy() {
         if (!m_doDestroy) return false;

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -201,15 +201,18 @@ private:
     }
 
     bool destroy() {
+        bool willDestroy = m_doDestroyData || m_doDestroyPointersToMatrices;
         if (m_doDestroyData) {
             if (m_d_data) gpuErrChk(cudaFree(m_d_data));
             m_d_data = nullptr;
+            m_doDestroyData = false;
         }
         if (m_doDestroyPointersToMatrices) {
             if (m_d_ptrMatrices) gpuErrChk(cudaFree(m_d_ptrMatrices));
             m_d_ptrMatrices = nullptr;
+            m_doDestroyPointersToMatrices = false;
         }
-        return m_doDestroyData || m_doDestroyPointersToMatrices;
+        return willDestroy;
     }
 
     /**

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -305,6 +305,10 @@ public:
      * @param axis axis to slice (0=rows, 1=columns, 2=matrices)
      * @param from index to slice axis from (zero-indexed)
      * @param to index to slice axis to (inclusive)
+     *
+     * @warning If axis=0 or axis=2, this method will (i) allocate memory on the GPU
+     * to store one element of size T* (pointer-to-T), (ii) will transfer one such
+     * element from the host to the device.
      */
     DTensor(const DTensor &other, size_t axis, size_t from, size_t to);
 

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -635,29 +635,6 @@ TEST_F(TensorTest, tensorMinusTensor) {
     tensorMinusTensor<double>();
 }
 
-/* ---------------------------------------
- * Tensor: pointers to matrices (on device)
- * --------------------------------------- */
-
-TEMPLATE_WITH_TYPE_T
-void tensorPointersToMatrices() {
-    std::vector<T> dataA = TENSOR_DATA_234A;
-    DTensor<T> A(dataA, 2, 3, 4);
-    DTensor<T *> pointers = A.pointersToMatrices();
-    EXPECT_EQ(4, pointers.numRows());
-    EXPECT_EQ(1, pointers.numCols());
-    EXPECT_EQ(1, pointers.numMats());
-    T *p1 = pointers(1, 0, 0); // pointer to matrix #1
-    T hostDst; // let's see what's there...
-    cudaMemcpy(&hostDst, p1, sizeof(T), cudaMemcpyDeviceToHost);
-    EXPECT_EQ(dataA[6], hostDst);
-}
-
-TEST_F(TensorTest, tensorPointersToMatrices) {
-    tensorPointersToMatrices<float>();
-    tensorPointersToMatrices<double>();
-    tensorPointersToMatrices<int>();
-}
 
 /* ---------------------------------------
  * Tensor: C = AB


### PR DESCRIPTION
# Moved to #50 

Please see #50 instead

## Main Changes

- Introduce `T** m_rawPtrToMatrices`, which is a raw pointer to the matrices of the tensor (to replace `pointersToMatrices`)


## TODOs

- [x] `addAB`: use `gemm` when `nMats=1`
- [x] Slicing: set `m_d_ptrMatrix = nullptr` when slicing with `axis=0` or `axis=1`
- [ ] `CholeskyBatchFactoriser`: get rid of `pointersToMatrices`
- [ ] `CholeskyBatchFactoriser`: throw error if `nMats=1`
- [ ] Reshaping: new test needed (e.g., reshape + multiply with `addAB`)

## Associated Issues

- Closes #48
