### PR TITLE
Better memory management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 <!-- ---------------------
+      v1.3.1
+     --------------------- -->
+## v1.3.1 - 8-11-2024
+
+### Fixed
+
+- Memory management improvements: we got rid of `pointerToMatrices`, which would unnecessarily allocate memory and `addAB` does not allocate any new memory internally.
+
+<!-- ---------------------
       v1.3.0
      --------------------- -->
 ## v1.3.0 - 11-10-2024 

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -998,18 +998,25 @@ inline void DTensor<float>::addAB(const DTensor<float> &A, const DTensor<float> 
     size_t nRA = A.numRows();
     size_t nCA = A.numCols();
     size_t nCB = B.numCols();
-    DTensor<float *> ptrA = A.pointersToMatrices();
-    DTensor<float *> ptrB = B.pointersToMatrices();
-    DTensor<float *> ptr = pointersToMatrices();
     float _alpha = alpha, _beta = beta;
-    gpuErrChk(cublasSgemmBatched(Session::getInstance().cuBlasHandle(),
-                                 CUBLAS_OP_N, CUBLAS_OP_N,
-                                 nRA, nCB, nCA, &_alpha,
-                                 ptrA.raw(), nRA,
-                                 ptrB.raw(), nCA,
-                                 &_beta,
-                                 ptr.raw(), nRA,
-                                 nMat));
+    if (nMat > 1) {
+        gpuErrChk(cublasSgemmBatched(Session::getInstance().cuBlasHandle(),
+                                     CUBLAS_OP_N, CUBLAS_OP_N,
+                                     nRA, nCB, nCA, &_alpha,
+                                     A.m_d_ptrMatrices, nRA,
+                                     B.m_d_ptrMatrices, nCA,
+                                     &_beta,
+                                     m_d_ptrMatrices, nRA,
+                                     nMat));
+    } else {
+        gpuErrChk(cublasSgemm(Session::getInstance().cuBlasHandle(),
+                              CUBLAS_OP_N, CUBLAS_OP_N,
+                              nRA, nCB, nCA, &_alpha,
+                              A.raw(), nRA,
+                              B.raw(), nCA,
+                              &_beta,
+                              raw(), nRA));
+    }
 }
 
 template<>

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -359,6 +359,7 @@ public:
      * Creates a vector of pointers to the matrices of this tensor.
      * The vector is an (n,1,1)-tensor, where n is the number of matrices in this tensor.
      * @return vector of pointers to the first element of each matrix
+     * @deprecated
      */
     DTensor<T *> pointersToMatrices() const;
 
@@ -1032,17 +1033,15 @@ inline void DTensor<double>::leastSquaresBatched(DTensor &B) {
     if (m_numCols > m_numRows)
         throw std::invalid_argument("[Least squares batched] supports square or tall matrices only");
     int info = 0;
-    DTensor<int> infoArray(batchSize);
-    DTensor<double *> As = pointersToMatrices();
-    DTensor<double *> Bs = B.pointersToMatrices();
+    DTensor<int> infoArray(batchSize); // TODO consider preallocating?
     gpuErrChk(cublasDgelsBatched(Session::getInstance().cuBlasHandle(),
                                  CUBLAS_OP_N,
                                  m_numRows,
                                  m_numCols,
                                  nColsB,
-                                 As.raw(),
+                                 m_d_ptrMatrices,
                                  m_numRows,
-                                 Bs.raw(),
+                                 B.m_d_ptrMatrices,
                                  m_numRows,
                                  &info,
                                  infoArray.raw(),
@@ -1062,17 +1061,15 @@ inline void DTensor<float>::leastSquaresBatched(DTensor &B) {
     if (m_numCols > m_numRows)
         throw std::invalid_argument("[Least squares batched] supports square or tall matrices only");
     int info = 0;
-    DTensor<int> infoArray(batchSize);
-    DTensor<float *> As = pointersToMatrices();
-    DTensor<float *> Bs = B.pointersToMatrices();
+    DTensor<int> infoArray(batchSize); // TODO consider preallocating?
     gpuErrChk(cublasSgelsBatched(Session::getInstance().cuBlasHandle(),
                                  CUBLAS_OP_N,
                                  m_numRows,
                                  m_numCols,
                                  nColsB,
-                                 As.raw(),
+                                 m_d_ptrMatrices,
                                  m_numRows,
-                                 Bs.raw(),
+                                 B.m_d_ptrMatrices,
                                  m_numRows,
                                  &info,
                                  infoArray.raw(),

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -471,6 +471,21 @@ public:
      */
     void addAB(const DTensor<T> &A, const DTensor<T> &B, T alpha = 1, T beta = 0);
 
+    /**
+     * Reshapes the tensor
+     *
+     * If the new number of tensors is larger than the current one,
+     * this method will allocate a device array of type T* and length
+     * equal to the new number of matrices.
+     *
+     * No new memory is allocated if newNumMats = 1
+     *
+     * @param newNumRows new number of rows
+     * @param newNumCols new number of columns
+     * @param newNumMats new number of matrices
+     *
+     * @throws std::invalid_argument if the provided dimensions are incompatible
+     */
     void reshape(size_t newNumRows, size_t newNumCols, size_t newNumMats = 1);
 
     /* ------------- OPERATORS ------------- */

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -287,7 +287,6 @@ public:
      * @param n number of columns
      * @param k number of matrices
      */
-
     DTensor(const std::vector<T> &data, size_t m, size_t n = 1, size_t k = 1,
             StorageMode mode = StorageMode::defaultMajor);
 
@@ -321,7 +320,7 @@ public:
      * Pointers to matrices (on device)
      * @return
      */
-    T **ptrMatrices();
+    T **ptrMatrices() const;
 
     /**
      * @return number of rows
@@ -847,7 +846,7 @@ inline T *DTensor<T>::raw() const {
 }
 
 template<typename T>
-inline T **DTensor<T>::ptrMatrices()  {
+inline T **DTensor<T>::ptrMatrices() const {
     return m_d_ptrMatrices;
 }
 

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -571,9 +571,13 @@ void DTensor<T>::reshape(size_t newNumRows, size_t newNumCols, size_t newNumMats
         if (m_d_ptrMatrices && m_doDestroyPtrMatrices) {
             gpuErrChk(cudaFree(m_d_ptrMatrices));
             m_d_ptrMatrices = nullptr;
+            m_doDestroyPtrMatrices = false;
         }
         /* Reallocate memory for m_d_ptrMatrices, if necessary */
-        if (newNumMats > 1) gpuErrChk(cudaMalloc(&m_d_ptrMatrices, newNumMats * sizeof(T *)));
+        if (newNumMats > 1) {
+            gpuErrChk(cudaMalloc(&m_d_ptrMatrices, newNumMats * sizeof(T *)));
+            m_doDestroyPtrMatrices = true;
+        }
     }
 
     m_numRows = newNumRows;

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -849,7 +849,8 @@ inline void DTensor<T>::allocateOnDevice(size_t size, bool zero) {
         m_doDestroyPtrMatrices = true;
         cudaStatus = cudaMalloc(&m_d_ptrMatrices, numMats() * sizeof(T *));
         if (cudaStatus != cudaSuccess) {
-            gpuErrChk(cudaFree(m_d_data));
+            gpuErrChk(cudaFree(m_d_data)); // ... free previously allocated memory
+            gpuErrChk(cudaStatus); // ... and memento mori
         }
     } else {
         m_doDestroyPtrMatrices = false;

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -317,6 +317,12 @@ public:
     T *raw() const;
 
     /**
+     * Pointers to matrices (on device)
+     * @return
+     */
+    T **ptrMatrices();
+
+    /**
      * @return number of rows
      */
     size_t numRows() const;
@@ -841,6 +847,12 @@ template<typename T>
 inline T *DTensor<T>::raw() const {
     return m_d_data;
 }
+
+template<typename T>
+inline T **DTensor<T>::ptrMatrices()  {
+    return m_d_ptrMatrices;
+}
+
 
 template<>
 inline DTensor<float> DTensor<float>::tr() const {

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -26,7 +26,7 @@ protected:
 
 TEMPLATE_WITH_TYPE_T
 void tensorConstructionZero() {
-    DTensor <T> zero(2, 3, 4, true);
+    DTensor<T> zero(2, 3, 4, true);
     EXPECT_EQ(2, zero.numRows());
     EXPECT_EQ(3, zero.numCols());
     EXPECT_EQ(4, zero.numMats());
@@ -65,21 +65,21 @@ void tensorConstructionStorageMode() {
     std::vector<T> Rm = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::vector<T> hostData(rows * cols * mats);
     // test constructor
-    DTensor <T> testCm(Cm, rows, cols, mats, columnMajor);
-    DTensor <T> testRm(Rm, rows, cols, mats, rowMajor);
+    DTensor<T> testCm(Cm, rows, cols, mats, columnMajor);
+    DTensor<T> testRm(Rm, rows, cols, mats, rowMajor);
     testCm.download(hostData);
     EXPECT_EQ(Cm, hostData);
     testRm.download(hostData);
     EXPECT_EQ(Cm, hostData);
     // test .upload()
-    DTensor <T> testSplitCm(rows, cols, mats);
-    DTensor <T> ACm(testSplitCm, 2, 0, 0);
-    DTensor <T> BCm(testSplitCm, 2, 1, 1);
+    DTensor<T> testSplitCm(rows, cols, mats);
+    DTensor<T> ACm(testSplitCm, 2, 0, 0);
+    DTensor<T> BCm(testSplitCm, 2, 1, 1);
     ACm.upload(aCm, columnMajor);
     BCm.upload(bCm, columnMajor);
-    DTensor <T> testSplitRm(rows, cols, mats);
-    DTensor <T> ARm(testSplitRm, 2, 0, 0);
-    DTensor <T> BRm(testSplitRm, 2, 1, 1);
+    DTensor<T> testSplitRm(rows, cols, mats);
+    DTensor<T> ARm(testSplitRm, 2, 0, 0);
+    DTensor<T> BRm(testSplitRm, 2, 1, 1);
     ARm.upload(aRm, rowMajor);
     BRm.upload(bRm, rowMajor);
     testSplitCm.download(hostData);
@@ -121,9 +121,9 @@ TEST_F(TensorTest, randomTensorCreation) {
 
 TEMPLATE_WITH_TYPE_T
 void tensorMoveConstructor() {
-    DTensor <T> zero(2, 3, 4, true);
-    DTensor <T> x(std::move(zero));
-    DTensor <T> y(DTensor < T > {100, 10, 1000});
+    DTensor<T> zero(2, 3, 4, true);
+    DTensor<T> x(std::move(zero));
+    DTensor<T> y(DTensor < T > {100, 10, 1000});
 }
 
 TEST_F(TensorTest, tensorMoveConstructor) {
@@ -142,7 +142,7 @@ TEST_F(TensorTest, tensorMoveConstructor) {
 TEMPLATE_WITH_TYPE_T
 void tensorConstructionFromVector() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     EXPECT_EQ(2, tenz.numRows());
     EXPECT_EQ(3, tenz.numCols());
     EXPECT_EQ(4, tenz.numMats());
@@ -162,8 +162,8 @@ TEST_F(TensorTest, tensorConstructionFromVector) {
 TEMPLATE_WITH_TYPE_T
 void tensorCopyConstructor() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
-    DTensor <T> tenzCp(tenz);
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenzCp(tenz);
     EXPECT_EQ(2, tenzCp.numRows());
     EXPECT_EQ(3, tenzCp.numCols());
     EXPECT_EQ(4, tenzCp.numMats());
@@ -188,8 +188,8 @@ TEST_F(TensorTest, tensorCopyConstructor) {
 TEMPLATE_WITH_TYPE_T
 void tensorSlicingConstructorAxis2() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tens(data, 2, 3, 4);
-    DTensor <T> tensSlice(tens, 2, 0, 1); // matrices #0 and #1
+    DTensor<T> tens(data, 2, 3, 4);
+    DTensor<T> tensSlice(tens, 2, 0, 1); // matrices #0 and #1
     EXPECT_EQ(2, tensSlice.numRows());
     EXPECT_EQ(3, tensSlice.numCols());
     EXPECT_EQ(2, tensSlice.numMats());
@@ -210,8 +210,8 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis2) {
 TEMPLATE_WITH_TYPE_T
 void tensorSlicingConstructorAxis1() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
-    DTensor <T> tenzSlice(tenz, 1, 1, 2); // columns from 1 to 2
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenzSlice(tenz, 1, 1, 2); // columns from 1 to 2
     EXPECT_EQ(2, tenzSlice.numRows());
     EXPECT_EQ(2, tenzSlice.numCols());
     EXPECT_EQ(1, tenzSlice.numMats());
@@ -235,8 +235,8 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis1) {
 TEMPLATE_WITH_TYPE_T
 void tensorSlicingConstructorAxis0() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
-    DTensor <T> tenzSlice(tenz, 0, 2, 3); // elements 2..3
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> tenzSlice(tenz, 0, 2, 3); // elements 2..3
     EXPECT_EQ(2, tenzSlice.numRows());
     EXPECT_EQ(1, tenzSlice.numCols());
     EXPECT_EQ(1, tenzSlice.numMats());
@@ -259,7 +259,7 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis0) {
 TEMPLATE_WITH_TYPE_T
 void tensorUpload() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(2, 3, 4);
+    DTensor<T> tenz(2, 3, 4);
     tenz.upload(data);
     EXPECT_EQ(2, tenz.numRows());
     EXPECT_EQ(3, tenz.numCols());
@@ -282,9 +282,9 @@ TEST_F(TensorTest, tensorUpload) {
 TEMPLATE_WITH_TYPE_T
 void tensorDeviceCopyTo() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
-    DTensor <T> other(2, 3, 5, true);
-    DTensor <T> z(other, 2, 1, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> other(2, 3, 5, true);
+    DTensor<T> z(other, 2, 1, 4);
     tenz.deviceCopyTo(z);
     std::vector<T> expected = {0, 0, 0, 0, 0, 0,
                                1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 10, 5, 4, 3, 2, 1, -1, 4, 3, 4, 3, 4, 8};
@@ -301,13 +301,13 @@ TEST_F(TensorTest, tensorDeviceCopyTo) {
 
 
 /* ---------------------------------------
- * Tensor: Frobenius dot product
+ * Tensor: Reshape
  * --------------------------------------- */
 
 TEMPLATE_WITH_TYPE_T
 void tensorReshape() {
     size_t m = 5, n = 10, k = 3;
-    DTensor <T> a = DTensor<T>::createRandomTensor(m, n, k, -1, 1); // dim = (m, n, k)
+    DTensor<T> a = DTensor<T>::createRandomTensor(m, n, k, -1, 1); // dim = (m, n, k)
     T lastElement = a(m - 1, n - 1, k - 1); // last element
     T firstElement = a(0, 0, 0);
     ASSERT_EQ(m, a.numRows());
@@ -344,6 +344,38 @@ TEST_F(TensorTest, tensorReshape) {
 }
 
 /* ---------------------------------------
+ * Tensor: Slice, reshape and add/multiply
+ * --------------------------------------- */
+
+TEMPLATE_WITH_TYPE_T
+void tensorSliceAndReshape(T epsilon) {
+    std::vector<T> dataA = TENSOR_DATA_234A;
+    std::vector<T> dataB = TENSOR_DATA_234B;
+    DTensor<T> a(dataA, 2, 3, 4);
+    DTensor<T> b(dataB, 2, 3, 4);
+
+    /* ---- Slicing axis = 2 ---- */
+    DTensor<T> aSlice(a, 2, 1, 3);
+    DTensor<T> bSlice(b, 2, 1, 3);
+    aSlice.reshape(2, 9, 1);
+    bSlice.reshape(2, 9, 1);
+    aSlice += bSlice;
+
+    std::vector<T> dataAExpected = {1, 2, 3, 4, 5, 6, 41, 7, 5, 5,
+                                    19, 17, 14, 13, 5, 11, -8, -4,
+                                    6, 8, 8, -2, 8, 13};
+    DTensor<T> aExpected(dataAExpected, 2, 3, 4);
+
+    DTensor<T> err = aExpected - a;
+    ASSERT_LT(err.normF(), epsilon);
+}
+
+TEST_F(TensorTest, tensorSliceAndReshape) {
+    tensorSliceAndReshape<float>(PRECISION_LOW);
+    tensorSliceAndReshape<double>(PRECISION_HIGH);
+}
+
+/* ---------------------------------------
  * Tensor: Frobenius dot product
  * --------------------------------------- */
 
@@ -352,13 +384,13 @@ void tensorDotF(T epsilon) {
     // as vectors
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor <T> vecA(dataA, dataA.size());
-    DTensor <T> vecB(dataB, dataB.size());
+    DTensor<T> vecA(dataA, dataA.size());
+    DTensor<T> vecB(dataB, dataB.size());
     T dotVector = vecA.dotF(vecB);
     EXPECT_EQ(604, dotVector);  // from MATLAB
     // as matrices
-    DTensor <T> tenA(dataA, 2, 3, 4);
-    DTensor <T> tenB(dataB, 2, 3, 4);
+    DTensor<T> tenA(dataA, 2, 3, 4);
+    DTensor<T> tenB(dataB, 2, 3, 4);
     T dotTensor = tenA.dotF(tenB);
     EXPECT_EQ(604, dotTensor);  // from MATLAB
 }
@@ -375,7 +407,7 @@ TEST_F(TensorTest, tensorDotF) {
 TEMPLATE_WITH_TYPE_T
 void tensorNormF(T epsilon) {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     EXPECT_NEAR(26.153393661244042, tenz.normF(), epsilon); // from MATLAB
 }
 
@@ -392,7 +424,7 @@ TEST_F(TensorTest, tensorNormF) {
 TEMPLATE_WITH_TYPE_T
 void tensorSumAbs() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     EXPECT_NEAR(112, tenz.sumAbs(), PRECISION_HIGH); // from MATLAB
 }
 
@@ -408,7 +440,7 @@ TEST_F(TensorTest, tensorSumAbs) {
 TEMPLATE_WITH_TYPE_T
 void tensorMax() {
     std::vector<T> data = TENSOR_DATA_234AMB;
-    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     T m = tenz.maxAbs();
     EXPECT_EQ(27, m);
 }
@@ -425,7 +457,7 @@ TEST_F(TensorTest, tensorMax) {
 TEMPLATE_WITH_TYPE_T
 void tensorMin() {
     std::vector<T> data = TENSOR_DATA_234AMB;
-    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     T m = tenz.minAbs();
     EXPECT_EQ(0, m);
 }
@@ -465,7 +497,7 @@ void tensorRightGivens(T epsilon) {
     }
 }
 
-TEST_F(TensorTest, tensorRightGivens ) {
+TEST_F(TensorTest, tensorRightGivens) {
     tensorRightGivens<float>(PRECISION_LOW);
     tensorRightGivens<double>(PRECISION_HIGH);
 }
@@ -515,7 +547,7 @@ TEST_F(TensorTest, tensorLeftGivens) {
 TEMPLATE_WITH_TYPE_T
 void tensorBracketOperator() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     EXPECT_EQ(1, tenz(0, 0, 0));
     EXPECT_EQ(3, tenz(0, 1, 2));
     EXPECT_EQ(8, tenz(1, 2, 3));
@@ -534,8 +566,8 @@ TEST_F(TensorTest, tensorBracketOperator) {
 TEMPLATE_WITH_TYPE_T
 void tensorAssignmentOperator() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor <T> tenz(data, 2, 3, 4);
-    DTensor <T> other;
+    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor<T> other;
     other = tenz;
     EXPECT_EQ(tenz.raw(), other.raw());
     EXPECT_EQ(2, other.numRows());
@@ -558,7 +590,7 @@ void tensorTimesEqualsScalar() {
     std::vector<T> data = TENSOR_DATA_234A;
     std::vector<T> dataTimes3 = {3, 6, 9, 12, 15, 18, 21, 24, 27, 24, 21, 30, 15, 12, 9, 6, 3, -3, 12, 9, 12, 9, 12,
                                  24};
-    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     tenz *= 3.0;
     std::vector<T> actual;
     tenz.download(actual);
@@ -579,7 +611,7 @@ void tensorTimesScalar() {
     std::vector<T> data = TENSOR_DATA_234A;
     std::vector<T> dataTimes3 = {3, 6, 9, 12, 15, 18, 21, 24, 27, 24, 21, 30, 15, 12, 9, 6, 3, -3, 12, 9, 12, 9, 12,
                                  24};
-    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor<T> tenz(data, 2, 3, 4);
     auto tripleTensor = 3.0 * tenz;
     std::vector<T> actual;
     tripleTensor.download(actual);
@@ -599,8 +631,8 @@ TEMPLATE_WITH_TYPE_T
 void tensorPlusEqualsTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor <T> A(dataA, 2, 3, 4);
-    DTensor <T> B(dataB, 2, 3, 4);
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T> B(dataB, 2, 3, 4);
     A += B;
     std::vector<T> expected = TENSOR_DATA_234APB;
     std::vector<T> actual;
@@ -621,8 +653,8 @@ TEMPLATE_WITH_TYPE_T
 void tensorMinusEqualsTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor <T> A(dataA, 2, 3, 4);
-    DTensor <T> B(dataB, 2, 3, 4);
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T> B(dataB, 2, 3, 4);
     A -= B;
     std::vector<T> expected = TENSOR_DATA_234AMB;
     std::vector<T> actual;
@@ -643,9 +675,9 @@ TEMPLATE_WITH_TYPE_T
 void tensorPlusTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor <T> A(dataA, 2, 3, 4);
-    DTensor <T> B(dataB, 2, 3, 4);
-    DTensor <T> C = A + B;
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T> B(dataB, 2, 3, 4);
+    DTensor<T> C = A + B;
     std::vector<T> expected = TENSOR_DATA_234APB;
     std::vector<T> actual;
     C.download(actual);
@@ -665,9 +697,9 @@ TEMPLATE_WITH_TYPE_T
 void tensorMinusTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor <T> A(dataA, 2, 3, 4);
-    DTensor <T> B(dataB, 2, 3, 4);
-    DTensor <T> C = A - B;
+    DTensor<T> A(dataA, 2, 3, 4);
+    DTensor<T> B(dataB, 2, 3, 4);
+    DTensor<T> C = A - B;
     std::vector<T> expected = TENSOR_DATA_234AMB;
     std::vector<T> actual;
     C.download(actual);
@@ -691,9 +723,9 @@ void tensorAddAB() {
     std::vector<T> bData = {6, 5, 4, 3, 2, 1,
                             7, 6, 5, 4, 3, 2,
                             1, 2, 1, 5, -6, 8};
-    DTensor <T> A(aData, 2, 3, 3);
-    DTensor <T> B(bData, 3, 2, 3);
-    DTensor <T> C(2, 2, 3, true);
+    DTensor<T> A(aData, 2, 3, 3);
+    DTensor<T> B(bData, 3, 2, 3);
+    DTensor<T> C(2, 2, 3, true);
     C.addAB(A, B);
     std::vector<T> expected = {41, 56, 14, 20, 158, 176, 77, 86, 60, 64, 111, 118};
     std::vector<T> actual;
@@ -718,14 +750,14 @@ void tensorGetRows() {
                             5., 6., 7.,
                             8., 9., 10.,
                             11., 12., 13};
-    DTensor <T> A(aData, 3, 3, 2);
-    DTensor <T> Ar0 = A.getRows(1, 1, 0);
+    DTensor<T> A(aData, 3, 3, 2);
+    DTensor<T> Ar0 = A.getRows(1, 1, 0);
     std::vector<T> expected0 = {25., 720., -1.};
     std::vector<T> actual0(3);
     Ar0.download(actual0);
     EXPECT_EQ(expected0, actual0);
 
-    DTensor <T> Ar1 = A.getRows(1, 2, 1);
+    DTensor<T> Ar1 = A.getRows(1, 2, 1);
     std::vector<T> expected1 = {6., 7., 9., 10., 12., 13.};
     std::vector<T> actual1(6);
     Ar1.download(actual1);
@@ -745,8 +777,8 @@ TEST_F(TensorTest, tensorGetRows) {
 TEMPLATE_WITH_TYPE_T
 void tensorTranspose() {
     std::vector<T> aData = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    DTensor <T> A(aData, 3, 2, 2);
-    DTensor <T> Atranspose = A.tr();
+    DTensor<T> A(aData, 3, 2, 2);
+    DTensor<T> Atranspose = A.tr();
     EXPECT_EQ(2, Atranspose.numRows());
     EXPECT_EQ(3, Atranspose.numCols());
     EXPECT_EQ(2, Atranspose.numMats());
@@ -786,12 +818,12 @@ void tensorLeastSquares1(T epsilon) {
                             6, 8,
                             -9, 20};
     std::vector<T> bData = {1, 1, -1, 2, 30, -80};
-    DTensor <T> A0(aData, 2, 2, 3);
-    DTensor <T> A(A0);
-    DTensor <T> B(bData, 2, 1, 3);
-    DTensor <T> sol(B);
+    DTensor<T> A0(aData, 2, 2, 3);
+    DTensor<T> A(A0);
+    DTensor<T> B(bData, 2, 1, 3);
+    DTensor<T> sol(B);
     A0.leastSquaresBatched(sol);
-    DTensor <T> C(2, 1, 3);
+    DTensor<T> C(2, 1, 3);
     C.addAB(A, sol);
     C -= B;
     T nrmErr = C.normF();
@@ -824,8 +856,8 @@ void singularValuesComputation(float epsilon) {
     std::vector<T> bData = {1, 6, 6, 6, 6, 6, 6, 6,
                             2, 7, 7, 7, 7, 7, 7, 7,
                             3, 8, 8, 8, 8, 8, 8, 8,};
-    DTensor <T> B(bData, 8, 3);
-    Svd <T> svd(B, true, false);
+    DTensor<T> B(bData, 8, 3);
+    Svd<T> svd(B, true, false);
     EXPECT_EQ(true, svd.factorise());
     auto S = svd.singularValues();
     EXPECT_NEAR(32.496241123753592, S(0), epsilon); // value from MATLAB
@@ -850,15 +882,15 @@ void singularValuesMemory(float epsilon) {
     std::vector<T> bData = {1, 6, 6, 6, 6, 6, 6, 6,
                             2, 7, 7, 7, 7, 7, 7, 7,
                             3, 8, 8, 8, 8, 8, 8, 8,};
-    DTensor <T> B(bData, 8, 3);
-    Svd <T> svd(B, true, false);
+    DTensor<T> B(bData, 8, 3);
+    Svd<T> svd(B, true, false);
     EXPECT_EQ(true, svd.factorise());
-    DTensor <T> const &v1 = svd.rightSingularVectors();
-    DTensor <T> const &v2 = svd.rightSingularVectors();
+    DTensor<T> const &v1 = svd.rightSingularVectors();
+    DTensor<T> const &v2 = svd.rightSingularVectors();
     EXPECT_EQ(&v1, &v2);
     EXPECT_EQ(v1.raw(), v2.raw());
-    DTensor <T> const &s1 = svd.singularValues();
-    DTensor <T> const &s2 = svd.singularValues();
+    DTensor<T> const &s1 = svd.singularValues();
+    DTensor<T> const &s2 = svd.singularValues();
     EXPECT_EQ(&s1, &s2);
     EXPECT_EQ(s1.raw(), s2.raw());
     auto u1 = svd.leftSingularVectors().value();
@@ -879,11 +911,11 @@ TEST_F(SvdTest, singularValuesMemory) {
 TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void singularValuesMultipleMatrices(float epsilon) {
     std::vector<T> aData = {1, 2, 3, 4, 5, 6, 1, 1, 1, 2, 2, 2, 0, 0, 0, 0, 0, 1};
-    DTensor <T> A(aData, 3, 2, 3);
-    Svd <T> svd(A, true); // do compute U (A will be destroyed)
+    DTensor<T> A(aData, 3, 2, 3);
+    Svd<T> svd(A, true); // do compute U (A will be destroyed)
     svd.factorise();
-    DTensor <T> const &S = svd.singularValues();
-    DTensor <T> const &V = svd.rightSingularVectors();
+    DTensor<T> const &S = svd.singularValues();
+    DTensor<T> const &V = svd.rightSingularVectors();
     auto Uopt = svd.leftSingularVectors();
     auto U = Uopt.value();
     std::vector<T> expected_v = {-0.386317703118612, -0.922365780077058, -0.922365780077058, 0.386317703118612,
@@ -928,9 +960,9 @@ void singularValuesRankMultipleMatrices(float epsilon) {
     std::vector<T> aData = {1, 4, 7, 10, 2, 5, 8, 11, 3, 6, 9, 0,
                             1, 4, 7, 10, 2, 5, 8, 11, 3, 6, 9, 12,
                             1, 2, 3, 4, 2, 4, 6, 8, 3, 6, 9, 12};
-    DTensor <T> A(aData, 4, 3, 3);
+    DTensor<T> A(aData, 4, 3, 3);
 
-    Svd <T> svd(A);
+    Svd<T> svd(A);
     svd.factorise();
     auto rank = svd.rank(epsilon);
     EXPECT_EQ(3, rank(0, 0, 0));
@@ -963,8 +995,8 @@ void choleskyFactorisation(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor <T> A(aData, 3, 3, 1);
-    CholeskyFactoriser <T> chol(A);
+    DTensor<T> A(aData, 3, 3, 1);
+    CholeskyFactoriser<T> chol(A);
     chol.factorise();
     EXPECT_NEAR(3.162277660168380, A(0, 0), epsilon);
     EXPECT_NEAR(-0.361403161162101, A(2, 1), epsilon);
@@ -985,14 +1017,14 @@ void choleskyFactorisationSolution(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor <T> A(aData, 3, 3, 1);
-    DTensor <T> L(A); // L = A
-    CholeskyFactoriser <T> chol(L);
+    DTensor<T> A(aData, 3, 3, 1);
+    DTensor<T> L(A); // L = A
+    CholeskyFactoriser<T> chol(L);
     chol.factorise();
 
     std::vector<T> bData = {-1., -3., 5.};
-    DTensor <T> rhs(bData, 3, 1, 1);
-    DTensor <T> sol(rhs);
+    DTensor<T> rhs(bData, 3, 1, 1);
+    DTensor<T> sol(rhs);
     chol.solve(sol);
 
     std::vector<T> expected = {-0.126805213103205, -0.128566396618528, 0.175061641423036};
@@ -1000,7 +1032,7 @@ void choleskyFactorisationSolution(T epsilon) {
     sol.download(actual);
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);
 
-    DTensor <T> error = A * sol;
+    DTensor<T> error = A * sol;
     error -= rhs;
     EXPECT_TRUE(error.normF() < epsilon);
 
@@ -1020,12 +1052,12 @@ void choleskyBatchFactorisation(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor <T> A(3, 3, 2);
-    DTensor <T> A0(A, 2, 0, 0);
-    DTensor <T> A1(A, 2, 1, 1);
+    DTensor<T> A(3, 3, 2);
+    DTensor<T> A0(A, 2, 0, 0);
+    DTensor<T> A1(A, 2, 1, 1);
     A0.upload(aData);
     A1.upload(aData);
-    CholeskyBatchFactoriser <T> chol(A);
+    CholeskyBatchFactoriser<T> chol(A);
     chol.factorise();
     // 0
     EXPECT_NEAR(3.162277660168380, A(0, 0, 0), epsilon);
@@ -1051,28 +1083,28 @@ void choleskyBatchFactorSolve(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor <T> A(3, 3, 2);
-    DTensor <T> A0(A, 2, 0, 0);
-    DTensor <T> A1(A, 2, 1, 1);
+    DTensor<T> A(3, 3, 2);
+    DTensor<T> A0(A, 2, 0, 0);
+    DTensor<T> A1(A, 2, 1, 1);
     A0.upload(aData);
     A1.upload(aData);
-    DTensor <T> L(A); // L = A
-    CholeskyBatchFactoriser <T> chol(L);
+    DTensor<T> L(A); // L = A
+    CholeskyBatchFactoriser<T> chol(L);
     chol.factorise();
     std::vector<T> bData = {-1., -3., 5.};
-    DTensor <T> rhs(3, 1, 2);
-    DTensor <T> rhs0(rhs, 2, 0, 0);
-    DTensor <T> rhs1(rhs, 2, 1, 1);
+    DTensor<T> rhs(3, 1, 2);
+    DTensor<T> rhs0(rhs, 2, 0, 0);
+    DTensor<T> rhs1(rhs, 2, 1, 1);
     rhs0.upload(bData);
     rhs1.upload(bData);
-    DTensor <T> sol(rhs);
+    DTensor<T> sol(rhs);
     chol.solve(sol);
     std::vector<T> expected = {-0.126805213103205, -0.128566396618528, 0.175061641423036};
     std::vector<T> actual(6);
     sol.download(actual);
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);  // 0
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i + 3], epsilon);  // 1
-    DTensor <T> error = A * sol;
+    DTensor<T> error = A * sol;
     error -= rhs;
     EXPECT_TRUE(error.normF() < epsilon);
 }
@@ -1091,35 +1123,35 @@ void choleskyBatchSolve(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor <T> A(3, 3, 2);
-    DTensor <T> A0(A, 2, 0, 0);
-    DTensor <T> A1(A, 2, 1, 1);
+    DTensor<T> A(3, 3, 2);
+    DTensor<T> A0(A, 2, 0, 0);
+    DTensor<T> A1(A, 2, 1, 1);
     A0.upload(aData);
     A1.upload(aData);
     std::vector<T> lowData = {3.162277660168380, 0, 0,
                               0.632455532033676, 4.427188724235731, 0,
                               0.948683298050514, -0.361403161162101, 5.382321781081287};  // from matlab
-    DTensor <T> low(3, 3, 2);
-    DTensor <T> low0(low, 2, 0, 0);
-    DTensor <T> low1(low, 2, 1, 1);
+    DTensor<T> low(3, 3, 2);
+    DTensor<T> low0(low, 2, 0, 0);
+    DTensor<T> low1(low, 2, 1, 1);
     low0.upload(lowData, rowMajor);
     low1.upload(lowData, rowMajor);
-    DTensor <T> L(low);
-    CholeskyBatchFactoriser <T> chol(L, true);
+    DTensor<T> L(low);
+    CholeskyBatchFactoriser<T> chol(L, true);
     std::vector<T> bData = {-1., -3., 5.};
-    DTensor <T> rhs(3, 1, 2);
-    DTensor <T> rhs0(rhs, 2, 0, 0);
-    DTensor <T> rhs1(rhs, 2, 1, 1);
+    DTensor<T> rhs(3, 1, 2);
+    DTensor<T> rhs0(rhs, 2, 0, 0);
+    DTensor<T> rhs1(rhs, 2, 1, 1);
     rhs0.upload(bData);
     rhs1.upload(bData);
-    DTensor <T> sol(rhs);
+    DTensor<T> sol(rhs);
     chol.solve(sol);
     std::vector<T> expected = {-0.126805213103205, -0.128566396618528, 0.175061641423036};
     std::vector<T> actual(6);
     sol.download(actual);
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);  // 0
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i + 3], epsilon);  // 1
-    DTensor <T> error = A * sol;
+    DTensor<T> error = A * sol;
     error -= rhs;
     EXPECT_TRUE(error.normF() < epsilon);
 }
@@ -1149,15 +1181,15 @@ TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void qrFactorisation(T epsilon) {
     size_t nR = 4;
     size_t nC = 3;
-    DTensor <T> temp(nR, nC);
-    DTensor <T> A = DTensor<T>::createRandomTensor(nR, nC, 1, -100, 100);
-    QRFactoriser <T> qr(temp);
+    DTensor<T> temp(nR, nC);
+    DTensor<T> A = DTensor<T>::createRandomTensor(nR, nC, 1, -100, 100);
+    QRFactoriser<T> qr(temp);
     A.deviceCopyTo(temp);
     int status = qr.factorise();
     EXPECT_EQ(status, 0);
-    DTensor <T> Q(nR, nC);
-    DTensor <T> R(nC, nC, 1, true);
-    DTensor <T> QR(nR, nC);
+    DTensor<T> Q(nR, nC);
+    DTensor<T> R(nC, nC, 1, true);
+    DTensor<T> QR(nR, nC);
     status = qr.getQR(Q, R);
     EXPECT_EQ(status, 0);
     QR.addAB(Q, R);
@@ -1180,15 +1212,15 @@ TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void qrFactorisationTall(T epsilon) {
     size_t nR = 20;
     size_t nC = 3;
-    DTensor <T> temp(nR, nC);
-    DTensor <T> A = DTensor<T>::createRandomTensor(nR, nC, 1, -100, 100);
-    QRFactoriser <T> qr(temp);
+    DTensor<T> temp(nR, nC);
+    DTensor<T> A = DTensor<T>::createRandomTensor(nR, nC, 1, -100, 100);
+    QRFactoriser<T> qr(temp);
     A.deviceCopyTo(temp);
     int status = qr.factorise();
     EXPECT_EQ(status, 0);
-    DTensor <T> Q(nR, nC);
-    DTensor <T> R(nC, nC, 1, true);
-    DTensor <T> QR(nR, nC);
+    DTensor<T> Q(nR, nC);
+    DTensor<T> R(nC, nC, 1, true);
+    DTensor<T> QR(nR, nC);
     status = qr.getQR(Q, R);
     EXPECT_EQ(status, 0);
     QR.addAB(Q, R);
@@ -1210,7 +1242,7 @@ TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void qrLeastSquares(T epsilon) {
     size_t nR = 4;
     size_t nC = 3;
-    DTensor <T> temp(nR, nC);
+    DTensor<T> temp(nR, nC);
     std::vector<T> vecA = {85.5638, -59.4001, -80.1992,
                            99.9464, 5.51393, 5.17935,
                            6.87488, -26.7536, 36.0914,
@@ -1219,12 +1251,12 @@ void qrLeastSquares(T epsilon) {
                            -48.5744,
                            43.4229,
                            -56.5081};  // Random vector
-    DTensor <T> A(vecA, nR, nC, 1, rowMajor);
-    DTensor <T> b(vecB, nR);
-    DTensor <T> xFull(nR);
-    DTensor <T> x(xFull, 0, 0, nC - 1);
-    DTensor <T> Ax(nR);
-    QRFactoriser <T> qr(temp);
+    DTensor<T> A(vecA, nR, nC, 1, rowMajor);
+    DTensor<T> b(vecB, nR);
+    DTensor<T> xFull(nR);
+    DTensor<T> x(xFull, 0, 0, nC - 1);
+    DTensor<T> Ax(nR);
+    QRFactoriser<T> qr(temp);
     A.deviceCopyTo(temp);
     int status = qr.factorise();
     EXPECT_EQ(status, 0);
@@ -1265,19 +1297,19 @@ void computeNullspaceTensor(T epsilon) {
                             1, 2, 3, 4, 2, 4, 6, 8, 3, 6, 9, 12,
                             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    DTensor <T> A(aData, 3, 4, 5);
-    Nullspace <T> ns(A);
-    DTensor <T> nA = ns.nullspace();
+    DTensor<T> A(aData, 3, 4, 5);
+    Nullspace<T> ns(A);
+    DTensor<T> nA = ns.nullspace();
     size_t nMats = nA.numMats();
     EXPECT_EQ(nMats, 5);
     for (size_t i = 0; i < nMats; i++) {
-        DTensor <T> nAi(nA, 2, i, i);
-        DTensor <T> Ai(A, 2, i, i);
-        DTensor <T> mustBeZero = Ai * nAi;
+        DTensor<T> nAi(nA, 2, i, i);
+        DTensor<T> Ai(A, 2, i, i);
+        DTensor<T> mustBeZero = Ai * nAi;
         EXPECT_LT(mustBeZero.normF(), epsilon);
 
-        DTensor <T> nAiTr = nAi.tr();
-        DTensor <T> mustBeEye = nAiTr * nAi;
+        DTensor<T> nAiTr = nAi.tr();
+        DTensor<T> mustBeEye = nAiTr * nAi;
         EXPECT_NEAR(1, mustBeEye(0, 0, 0), epsilon);
         for (size_t ir = 0; ir < mustBeEye.numRows(); ir++) {
             for (size_t ic = 0; ic < mustBeEye.numCols(); ic++) {
@@ -1306,9 +1338,9 @@ void computeNullspaceTrivial(T epsilon) {
                         1, 1, 1,
                         5, 6, 7,
                         9, 0, 3};
-    DTensor <T> A(data, 3, 3, 2, rowMajor);
-    Nullspace <T> nullA(A);
-    DTensor <T> N = nullA.nullspace();
+    DTensor<T> A(data, 3, 3, 2, rowMajor);
+    Nullspace<T> nullA(A);
+    DTensor<T> N = nullA.nullspace();
     EXPECT_EQ(N.normF(), 0);
 }
 
@@ -1329,28 +1361,28 @@ void projectOnNullspaceTensor(T epsilon) {
     std::vector<T> mat{1, -2, 3, 4, -1, -1, -1,
                        1, 2, -3, 4, -1, -1, -1,
                        -1, 3, 5, -7, -1, -1, -1};
-    DTensor <T> A(m, n, 1);
+    DTensor<T> A(m, n, 1);
     A.upload(mat, rowMajor);
-    Nullspace <T> ns = Nullspace(A);
-    DTensor <T> N = ns.nullspace();
+    Nullspace<T> ns = Nullspace(A);
+    DTensor<T> N = ns.nullspace();
 
     // online
     std::vector<T> vec{1, 2, 3, 4, 5, 6, 7};
-    DTensor <T> x(vec, n);
-    DTensor <T> proj(x);
+    DTensor<T> x(vec, n);
+    DTensor<T> proj(x);
     ns.project(proj);
 
     // Testing that proj is indeed in ker A
-    DTensor <T> error(m, 1, 1, true);
+    DTensor<T> error(m, 1, 1, true);
     error.addAB(A, proj);
     EXPECT_TRUE(error.normF() < epsilon);
 
     // Orthogonality test (other - p) † (p - x)
     std::vector<T> h_other{1, -2, 5, 4, 0, 0, 0};
-    DTensor <T> other(h_other, n);
-    DTensor <T> y = N * other;
-    DTensor <T> delta1 = y - proj;
-    DTensor <T> delta2 = proj - x;
+    DTensor<T> other(h_other, n);
+    DTensor<T> y = N * other;
+    DTensor<T> delta1 = y - proj;
+    DTensor<T> delta2 = proj - x;
     EXPECT_LT(delta1.dotF(delta2), epsilon);
 }
 

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -636,30 +636,6 @@ TEST_F(TensorTest, tensorMinusTensor) {
 }
 
 /* ---------------------------------------
- * Tensor: pointers to matrices (on device)
- * --------------------------------------- */
-
-TEMPLATE_WITH_TYPE_T
-void tensorPointersToMatrices() {
-    std::vector<T> dataA = TENSOR_DATA_234A;
-    DTensor<T> A(dataA, 2, 3, 4);
-    DTensor<T *> pointers = A.pointersToMatrices();
-    EXPECT_EQ(4, pointers.numRows());
-    EXPECT_EQ(1, pointers.numCols());
-    EXPECT_EQ(1, pointers.numMats());
-    T *p1 = pointers(1, 0, 0); // pointer to matrix #1
-    T hostDst; // let's see what's there...
-    cudaMemcpy(&hostDst, p1, sizeof(T), cudaMemcpyDeviceToHost);
-    EXPECT_EQ(dataA[6], hostDst);
-}
-
-TEST_F(TensorTest, tensorPointersToMatrices) {
-    tensorPointersToMatrices<float>();
-    tensorPointersToMatrices<double>();
-    tensorPointersToMatrices<int>();
-}
-
-/* ---------------------------------------
  * Tensor: C = AB
  * --------------------------------------- */
 

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -36,14 +36,10 @@ void tensorConstructionZero() {
     EXPECT_EQ(expectedResult, zeroDown);
 }
 
-TEST_F(TensorTest, tensorConstructionZero
-) {
-tensorConstructionZero<float>();
-
-tensorConstructionZero<double>();
-
-tensorConstructionZero<int>();
-
+TEST_F(TensorTest, tensorConstructionZero) {
+    tensorConstructionZero<float>();
+    tensorConstructionZero<double>();
+    tensorConstructionZero<int>();
 }
 
 /* ---------------------------------------
@@ -92,14 +88,10 @@ void tensorConstructionStorageMode() {
     EXPECT_EQ(Cm, hostData);
 }
 
-TEST_F(TensorTest, tensorConstructionStorageMode
-) {
-tensorConstructionStorageMode<float>();
-
-tensorConstructionStorageMode<double>();
-
-tensorConstructionStorageMode<int>();
-
+TEST_F(TensorTest, tensorConstructionStorageMode) {
+    tensorConstructionStorageMode<float>();
+    tensorConstructionStorageMode<double>();
+    tensorConstructionStorageMode<int>();
 }
 
 /* ---------------------------------------
@@ -117,14 +109,10 @@ void randomTensorCreation() {
     EXPECT_TRUE(rEle >= -1 && rEle <= 1);
 }
 
-TEST_F(TensorTest, randomTensorCreation
-) {
-randomTensorCreation<float>();
-
-randomTensorCreation<double>();
-
-randomTensorCreation<int>();
-
+TEST_F(TensorTest, randomTensorCreation) {
+    randomTensorCreation<float>();
+    randomTensorCreation<double>();
+    randomTensorCreation<int>();
 }
 
 /* ---------------------------------------
@@ -138,18 +126,12 @@ void tensorMoveConstructor() {
     DTensor <T> y(DTensor < T > {100, 10, 1000});
 }
 
-TEST_F(TensorTest, tensorMoveConstructor
-) {
-tensorMoveConstructor<float>();
-
-tensorMoveConstructor<double>();
-
-tensorMoveConstructor<int>();
-
-tensorMoveConstructor<int *>();
-
-tensorMoveConstructor<double *>();
-
+TEST_F(TensorTest, tensorMoveConstructor) {
+    tensorMoveConstructor<float>();
+    tensorMoveConstructor<double>();
+    tensorMoveConstructor<int>();
+    tensorMoveConstructor<int *>();
+    tensorMoveConstructor<double *>();
 }
 
 /* ---------------------------------------
@@ -167,14 +149,10 @@ void tensorConstructionFromVector() {
     EXPECT_EQ(2 * 3 * 4, tenz.numEl());
 }
 
-TEST_F(TensorTest, tensorConstructionFromVector
-) {
-tensorConstructionFromVector<float>();
-
-tensorConstructionFromVector<double>();
-
-tensorConstructionFromVector<int>();
-
+TEST_F(TensorTest, tensorConstructionFromVector) {
+    tensorConstructionFromVector<float>();
+    tensorConstructionFromVector<double>();
+    tensorConstructionFromVector<int>();
 }
 
 /* ---------------------------------------
@@ -196,14 +174,10 @@ void tensorCopyConstructor() {
     EXPECT_NE(tenz.raw(), tenzCp.raw());
 }
 
-TEST_F(TensorTest, tensorCopyConstructor
-) {
-tensorCopyConstructor<float>();
-
-tensorCopyConstructor<double>();
-
-tensorCopyConstructor<int>();
-
+TEST_F(TensorTest, tensorCopyConstructor) {
+    tensorCopyConstructor<float>();
+    tensorCopyConstructor<double>();
+    tensorCopyConstructor<int>();
 }
 
 /* ---------------------------------------
@@ -222,14 +196,10 @@ void tensorSlicingConstructorAxis2() {
     EXPECT_EQ(tens.raw(), tensSlice.raw()); // it is indeed a slice
 }
 
-TEST_F(TensorTest, tensorSlicingConstructorAxis2
-) {
-tensorSlicingConstructorAxis2<float>();
-
-tensorSlicingConstructorAxis2<double>();
-
-tensorSlicingConstructorAxis2<int>();
-
+TEST_F(TensorTest, tensorSlicingConstructorAxis2) {
+    tensorSlicingConstructorAxis2<float>();
+    tensorSlicingConstructorAxis2<double>();
+    tensorSlicingConstructorAxis2<int>();
 }
 
 /* ---------------------------------------
@@ -251,14 +221,10 @@ void tensorSlicingConstructorAxis1() {
     EXPECT_EQ(expected, tenzSliceDown);
 }
 
-TEST_F(TensorTest, tensorSlicingConstructorAxis1
-) {
-tensorSlicingConstructorAxis1<float>();
-
-tensorSlicingConstructorAxis1<double>();
-
-tensorSlicingConstructorAxis1<int>();
-
+TEST_F(TensorTest, tensorSlicingConstructorAxis1) {
+    tensorSlicingConstructorAxis1<float>();
+    tensorSlicingConstructorAxis1<double>();
+    tensorSlicingConstructorAxis1<int>();
 }
 
 /* ---------------------------------------
@@ -280,14 +246,10 @@ void tensorSlicingConstructorAxis0() {
     EXPECT_EQ(expected, tenzSliceDown);
 }
 
-TEST_F(TensorTest, tensorSlicingConstructorAxis0
-) {
-tensorSlicingConstructorAxis0<float>();
-
-tensorSlicingConstructorAxis0<double>();
-
-tensorSlicingConstructorAxis0<int>();
-
+TEST_F(TensorTest, tensorSlicingConstructorAxis0) {
+    tensorSlicingConstructorAxis0<float>();
+    tensorSlicingConstructorAxis0<double>();
+    tensorSlicingConstructorAxis0<int>();
 }
 
 /* ---------------------------------------
@@ -307,14 +269,10 @@ void tensorUpload() {
     EXPECT_EQ(8, tenz(1, 2, 3));
 }
 
-TEST_F(TensorTest, tensorUpload
-) {
-tensorUpload<float>();
-
-tensorUpload<double>();
-
-tensorUpload<int>();
-
+TEST_F(TensorTest, tensorUpload) {
+    tensorUpload<float>();
+    tensorUpload<double>();
+    tensorUpload<int>();
 }
 
 /* ---------------------------------------
@@ -335,14 +293,10 @@ void tensorDeviceCopyTo() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorDeviceCopyTo
-) {
-tensorDeviceCopyTo<float>();
-
-tensorDeviceCopyTo<double>();
-
-tensorDeviceCopyTo<int>();
-
+TEST_F(TensorTest, tensorDeviceCopyTo) {
+    tensorDeviceCopyTo<float>();
+    tensorDeviceCopyTo<double>();
+    tensorDeviceCopyTo<int>();
 }
 
 
@@ -354,6 +308,8 @@ TEMPLATE_WITH_TYPE_T
 void tensorReshape() {
     size_t m = 5, n = 10, k = 3;
     DTensor <T> a = DTensor<T>::createRandomTensor(m, n, k, -1, 1); // dim = (m, n, k)
+    T lastElement = a(m - 1, n - 1, k - 1); // last element
+    T firstElement = a(0, 0, 0);
     ASSERT_EQ(m, a.numRows());
     ASSERT_EQ(n, a.numCols());
     ASSERT_EQ(k, a.numMats());
@@ -365,6 +321,20 @@ void tensorReshape() {
     ASSERT_EQ(k, a.numRows());
     ASSERT_EQ(n, a.numCols());
     ASSERT_EQ(m, a.numMats());
+    a.reshape(k * n, m, 1); // dim = (k*n, m, 1)
+    ASSERT_EQ(k * n, a.numRows());
+    ASSERT_EQ(m, a.numCols());
+    ASSERT_EQ(1, a.numMats());
+    a.reshape(m, k * n, 1); // dim = (m, k*n, 1)
+    ASSERT_EQ(m, a.numRows());
+    ASSERT_EQ(k * n, a.numCols());
+    ASSERT_EQ(1, a.numMats());
+    a.reshape(m * k * n, 1, 1); // dim = (m*k*n, 1, 1)
+    ASSERT_EQ(m * k * n, a.numRows());
+    ASSERT_EQ(1, a.numCols());
+    ASSERT_EQ(1, a.numMats());
+    ASSERT_EQ(lastElement, a(m * n * k - 1, 0, 0));
+    ASSERT_EQ(firstElement, a(0, 0, 0));
 }
 
 TEST_F(TensorTest, tensorReshape) {
@@ -393,10 +363,9 @@ void tensorDotF(T epsilon) {
     EXPECT_EQ(604, dotTensor);  // from MATLAB
 }
 
-TEST_F(TensorTest, tensorDotF
-) {
-tensorDotF<float>(PRECISION_LOW);
-tensorDotF<double>(PRECISION_HIGH);
+TEST_F(TensorTest, tensorDotF) {
+    tensorDotF<float>(PRECISION_LOW);
+    tensorDotF<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -410,10 +379,9 @@ void tensorNormF(T epsilon) {
     EXPECT_NEAR(26.153393661244042, tenz.normF(), epsilon); // from MATLAB
 }
 
-TEST_F(TensorTest, tensorNormF
-) {
-tensorNormF<float>(PRECISION_LOW);
-tensorNormF<double>(PRECISION_HIGH);
+TEST_F(TensorTest, tensorNormF) {
+    tensorNormF<float>(PRECISION_LOW);
+    tensorNormF<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -428,12 +396,9 @@ void tensorSumAbs() {
     EXPECT_NEAR(112, tenz.sumAbs(), PRECISION_HIGH); // from MATLAB
 }
 
-TEST_F(TensorTest, tensorSumAbs
-) {
-tensorSumAbs<float>();
-
-tensorSumAbs<double>();
-
+TEST_F(TensorTest, tensorSumAbs) {
+    tensorSumAbs<float>();
+    tensorSumAbs<double>();
 }
 
 /* ---------------------------------------
@@ -448,12 +413,9 @@ void tensorMax() {
     EXPECT_EQ(27, m);
 }
 
-TEST_F(TensorTest, tensorMax
-) {
-tensorMax<float>();
-
-tensorMax<double>();
-
+TEST_F(TensorTest, tensorMax) {
+    tensorMax<float>();
+    tensorMax<double>();
 }
 
 /* ---------------------------------------
@@ -468,12 +430,9 @@ void tensorMin() {
     EXPECT_EQ(0, m);
 }
 
-TEST_F(TensorTest, tensorMin
-) {
-tensorMin<float>();
-
-tensorMin<double>();
-
+TEST_F(TensorTest, tensorMin) {
+    tensorMin<float>();
+    tensorMin<double>();
 }
 
 /* ---------------------------------------
@@ -506,10 +465,9 @@ void tensorRightGivens(T epsilon) {
     }
 }
 
-TEST_F(TensorTest, tensorRightGivens
-) {
-tensorRightGivens<float>(PRECISION_LOW);
-tensorRightGivens<double>(PRECISION_HIGH);
+TEST_F(TensorTest, tensorRightGivens ) {
+    tensorRightGivens<float>(PRECISION_LOW);
+    tensorRightGivens<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -544,10 +502,9 @@ void tensorLeftGivens(T epsilon) {
     }
 }
 
-TEST_F(TensorTest, tensorLeftGivens
-) {
-tensorLeftGivens<float>(1e-10);
-tensorLeftGivens<double>(1e-14);
+TEST_F(TensorTest, tensorLeftGivens) {
+    tensorLeftGivens<float>(1e-10);
+    tensorLeftGivens<double>(1e-14);
 }
 
 /* ---------------------------------------
@@ -564,14 +521,10 @@ void tensorBracketOperator() {
     EXPECT_EQ(8, tenz(1, 2, 3));
 }
 
-TEST_F(TensorTest, tensorBracketOperator
-) {
-tensorBracketOperator<float>();
-
-tensorBracketOperator<double>();
-
-tensorBracketOperator<int>();
-
+TEST_F(TensorTest, tensorBracketOperator) {
+    tensorBracketOperator<float>();
+    tensorBracketOperator<double>();
+    tensorBracketOperator<int>();
 }
 
 /* ---------------------------------------
@@ -590,14 +543,10 @@ void tensorAssignmentOperator() {
     EXPECT_EQ(4, other.numMats());
 }
 
-TEST_F(TensorTest, tensorAssignmentOperator
-) {
-tensorAssignmentOperator<float>();
-
-tensorAssignmentOperator<double>();
-
-tensorAssignmentOperator<int>();
-
+TEST_F(TensorTest, tensorAssignmentOperator) {
+    tensorAssignmentOperator<float>();
+    tensorAssignmentOperator<double>();
+    tensorAssignmentOperator<int>();
 }
 
 /* ---------------------------------------
@@ -616,12 +565,9 @@ void tensorTimesEqualsScalar() {
     EXPECT_EQ(dataTimes3, actual);
 }
 
-TEST_F(TensorTest, tensorTimesEqualsScalar
-) {
-tensorTimesEqualsScalar<float>();
-
-tensorTimesEqualsScalar<double>();
-
+TEST_F(TensorTest, tensorTimesEqualsScalar) {
+    tensorTimesEqualsScalar<float>();
+    tensorTimesEqualsScalar<double>();
 }
 
 /* ---------------------------------------
@@ -640,12 +586,9 @@ void tensorTimesScalar() {
     EXPECT_EQ(dataTimes3, actual);
 }
 
-TEST_F(TensorTest, tensorTimesScalar
-) {
-tensorTimesScalar<float>();
-
-tensorTimesScalar<double>();
-
+TEST_F(TensorTest, tensorTimesScalar) {
+    tensorTimesScalar<float>();
+    tensorTimesScalar<double>();
 }
 
 /* ---------------------------------------
@@ -665,12 +608,9 @@ void tensorPlusEqualsTensor() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorPlusEqualsTensor
-) {
-tensorPlusEqualsTensor<float>();
-
-tensorPlusEqualsTensor<double>();
-
+TEST_F(TensorTest, tensorPlusEqualsTensor) {
+    tensorPlusEqualsTensor<float>();
+    tensorPlusEqualsTensor<double>();
 }
 
 /* ---------------------------------------
@@ -690,12 +630,9 @@ void tensorMinusEqualsTensor() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorMinusEqualsTensor
-) {
-tensorMinusEqualsTensor<float>();
-
-tensorMinusEqualsTensor<double>();
-
+TEST_F(TensorTest, tensorMinusEqualsTensor) {
+    tensorMinusEqualsTensor<float>();
+    tensorMinusEqualsTensor<double>();
 }
 
 /* ---------------------------------------
@@ -715,12 +652,9 @@ void tensorPlusTensor() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorPlusTensor
-) {
-tensorPlusTensor<float>();
-
-tensorPlusTensor<double>();
-
+TEST_F(TensorTest, tensorPlusTensor) {
+    tensorPlusTensor<float>();
+    tensorPlusTensor<double>();
 }
 
 /* ---------------------------------------
@@ -740,12 +674,9 @@ void tensorMinusTensor() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorMinusTensor
-) {
-tensorMinusTensor<float>();
-
-tensorMinusTensor<double>();
-
+TEST_F(TensorTest, tensorMinusTensor) {
+    tensorMinusTensor<float>();
+    tensorMinusTensor<double>();
 }
 
 /* ---------------------------------------
@@ -770,12 +701,9 @@ void tensorAddAB() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorAddAB
-) {
-tensorAddAB<double>();
-
-tensorAddAB<float>();
-
+TEST_F(TensorTest, tensorAddAB) {
+    tensorAddAB<double>();
+    tensorAddAB<float>();
 }
 
 /* ---------------------------------------
@@ -804,12 +732,9 @@ void tensorGetRows() {
     EXPECT_EQ(expected1, actual1);
 }
 
-TEST_F(TensorTest, tensorGetRows
-) {
-tensorGetRows<float>();
-
-tensorGetRows<double>();
-
+TEST_F(TensorTest, tensorGetRows) {
+    tensorGetRows<float>();
+    tensorGetRows<double>();
 }
 
 
@@ -832,12 +757,9 @@ void tensorTranspose() {
 
 }
 
-TEST_F(TensorTest, tensorTranspose
-) {
-tensorTranspose<float>();
-
-tensorTranspose<double>();
-
+TEST_F(TensorTest, tensorTranspose) {
+    tensorTranspose<float>();
+    tensorTranspose<double>();
 }
 
 /* ================================================================================================
@@ -876,10 +798,9 @@ void tensorLeastSquares1(T epsilon) {
     EXPECT_LT(nrmErr, epsilon);
 }
 
-TEST_F(LeastSquaresTest, tensorLS1
-) {
-tensorLeastSquares1<float>(PRECISION_LOW);
-tensorLeastSquares1<double>(PRECISION_HIGH);
+TEST_F(LeastSquaresTest, tensorLS1) {
+    tensorLeastSquares1<float>(PRECISION_LOW);
+    tensorLeastSquares1<double>(PRECISION_HIGH);
 }
 
 
@@ -914,10 +835,9 @@ void singularValuesComputation(float epsilon) {
     EXPECT_TRUE(U.has_value());
 }
 
-TEST_F(SvdTest, singularValuesComputation
-) {
-singularValuesComputation<float>(PRECISION_LOW);
-singularValuesComputation<double>(PRECISION_HIGH);
+TEST_F(SvdTest, singularValuesComputation) {
+    singularValuesComputation<float>(PRECISION_LOW);
+    singularValuesComputation<double>(PRECISION_HIGH);
 }
 
 
@@ -947,10 +867,9 @@ void singularValuesMemory(float epsilon) {
     EXPECT_EQ(u1->raw(), u2->raw());
 }
 
-TEST_F(SvdTest, singularValuesMemory
-) {
-singularValuesMemory<float>(PRECISION_LOW);
-singularValuesMemory<double>(PRECISION_HIGH);
+TEST_F(SvdTest, singularValuesMemory) {
+    singularValuesMemory<float>(PRECISION_LOW);
+    singularValuesMemory<double>(PRECISION_HIGH);
 }
 
 
@@ -994,10 +913,9 @@ void singularValuesMultipleMatrices(float epsilon) {
 
 }
 
-TEST_F(SvdTest, singularValuesMultipleMatrices
-) {
-singularValuesMultipleMatrices<float>(10 * PRECISION_LOW); // SVD with float performs quite poorly
-singularValuesMultipleMatrices<double>(PRECISION_HIGH);
+TEST_F(SvdTest, singularValuesMultipleMatrices) {
+    singularValuesMultipleMatrices<float>(10 * PRECISION_LOW); // SVD with float performs quite poorly
+    singularValuesMultipleMatrices<double>(PRECISION_HIGH);
 }
 
 
@@ -1020,10 +938,9 @@ void singularValuesRankMultipleMatrices(float epsilon) {
     EXPECT_EQ(1, rank(0, 0, 2));
 }
 
-TEST_F(SvdTest, singularValuesRankMultipleMatrices
-) {
-singularValuesRankMultipleMatrices<float>(PRECISION_LOW); // SVD with float performs quite poorly
-singularValuesRankMultipleMatrices<double>(PRECISION_HIGH);
+TEST_F(SvdTest, singularValuesRankMultipleMatrices) {
+    singularValuesRankMultipleMatrices<float>(PRECISION_LOW); // SVD with float performs quite poorly
+    singularValuesRankMultipleMatrices<double>(PRECISION_HIGH);
 }
 
 /* ================================================================================================
@@ -1054,10 +971,9 @@ void choleskyFactorisation(T epsilon) {
     EXPECT_NEAR(5.382321781081287, A(2, 2), epsilon);
 }
 
-TEST_F(CholeskyTest, choleskyFactorisation
-) {
-choleskyFactorisation<float>(PRECISION_LOW);
-choleskyFactorisation<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyFactorisation) {
+    choleskyFactorisation<float>(PRECISION_LOW);
+    choleskyFactorisation<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1090,10 +1006,9 @@ void choleskyFactorisationSolution(T epsilon) {
 
 }
 
-TEST_F(CholeskyTest, choleskyFactorisationSolution
-) {
-choleskyFactorisationSolution<float>(PRECISION_LOW);
-choleskyFactorisationSolution<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyFactorisationSolution) {
+    choleskyFactorisationSolution<float>(PRECISION_LOW);
+    choleskyFactorisationSolution<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1122,10 +1037,9 @@ void choleskyBatchFactorisation(T epsilon) {
     EXPECT_NEAR(5.382321781081287, A(2, 2, 1), epsilon);
 }
 
-TEST_F(CholeskyTest, choleskyBatchFactorisation
-) {
-choleskyBatchFactorisation<float>(PRECISION_LOW);
-choleskyBatchFactorisation<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyBatchFactorisation) {
+    choleskyBatchFactorisation<float>(PRECISION_LOW);
+    choleskyBatchFactorisation<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1163,10 +1077,9 @@ void choleskyBatchFactorSolve(T epsilon) {
     EXPECT_TRUE(error.normF() < epsilon);
 }
 
-TEST_F(CholeskyTest, choleskyBatchFactorSolve
-) {
-choleskyBatchFactorSolve<float>(PRECISION_LOW);
-choleskyBatchFactorSolve<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyBatchFactorSolve) {
+    choleskyBatchFactorSolve<float>(PRECISION_LOW);
+    choleskyBatchFactorSolve<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1211,10 +1124,9 @@ void choleskyBatchSolve(T epsilon) {
     EXPECT_TRUE(error.normF() < epsilon);
 }
 
-TEST_F(CholeskyTest, choleskyBatchSolve
-) {
-choleskyBatchSolve<float>(PRECISION_LOW);
-choleskyBatchSolve<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyBatchSolve) {
+    choleskyBatchSolve<float>(PRECISION_LOW);
+    choleskyBatchSolve<double>(PRECISION_HIGH);
 }
 
 
@@ -1254,10 +1166,9 @@ void qrFactorisation(T epsilon) {
     EXPECT_NEAR(nrm, 0., epsilon);
 }
 
-TEST_F(QRTest, qrFactorisation
-) {
-qrFactorisation<float>(PRECISION_LOW);
-qrFactorisation<double>(PRECISION_HIGH);
+TEST_F(QRTest, qrFactorisation) {
+    qrFactorisation<float>(PRECISION_LOW);
+    qrFactorisation<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1286,10 +1197,9 @@ void qrFactorisationTall(T epsilon) {
     EXPECT_NEAR(nrm, 0., epsilon);
 }
 
-TEST_F(QRTest, qrFactorisationTall
-) {
-qrFactorisationTall<float>(PRECISION_LOW);
-qrFactorisationTall<double>(PRECISION_HIGH);
+TEST_F(QRTest, qrFactorisationTall) {
+    qrFactorisationTall<float>(PRECISION_LOW);
+    qrFactorisationTall<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1327,10 +1237,9 @@ void qrLeastSquares(T epsilon) {
     EXPECT_NEAR(nrm, 80.003169364198072, epsilon);  // From MatLab
 }
 
-TEST_F(QRTest, qrLeastSquares
-) {
-qrLeastSquares<float>(PRECISION_LOW);
-qrLeastSquares<double>(PRECISION_HIGH);
+TEST_F(QRTest, qrLeastSquares) {
+    qrLeastSquares<float>(PRECISION_LOW);
+    qrLeastSquares<double>(PRECISION_HIGH);
 }
 
 
@@ -1380,10 +1289,9 @@ void computeNullspaceTensor(T epsilon) {
     }
 }
 
-TEST_F(NullspaceTest, computeNullspaceTensor
-) {
-computeNullspaceTensor<float>(PRECISION_LOW);
-computeNullspaceTensor<double>(PRECISION_HIGH);
+TEST_F(NullspaceTest, computeNullspaceTensor) {
+    computeNullspaceTensor<float>(PRECISION_LOW);
+    computeNullspaceTensor<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1404,10 +1312,9 @@ void computeNullspaceTrivial(T epsilon) {
     EXPECT_EQ(N.normF(), 0);
 }
 
-TEST_F(NullspaceTest, computeNullspaceTrivial
-) {
-computeNullspaceTrivial<float>(PRECISION_LOW);
-computeNullspaceTrivial<double>(PRECISION_HIGH);
+TEST_F(NullspaceTest, computeNullspaceTrivial) {
+    computeNullspaceTrivial<float>(PRECISION_LOW);
+    computeNullspaceTrivial<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1447,10 +1354,9 @@ void projectOnNullspaceTensor(T epsilon) {
     EXPECT_LT(delta1.dotF(delta2), epsilon);
 }
 
-TEST_F(NullspaceTest, projectOnNullspaceTensor
-) {
-projectOnNullspaceTensor<float>(PRECISION_LOW);
-projectOnNullspaceTensor<double>(PRECISION_HIGH);
+TEST_F(NullspaceTest, projectOnNullspaceTensor) {
+    projectOnNullspaceTensor<float>(PRECISION_LOW);
+    projectOnNullspaceTensor<double>(PRECISION_HIGH);
 }
 
 
@@ -1488,10 +1394,9 @@ void givensAnnihilateElement(T epsilon) {
     }
 }
 
-TEST_F(GivensAnnihilatorTest, givensAnnihilateElement
-) {
-givensAnnihilateElement<float>(PRECISION_LOW);
-givensAnnihilateElement<double>(PRECISION_HIGH);
+TEST_F(GivensAnnihilatorTest, givensAnnihilateElement) {
+    givensAnnihilateElement<float>(PRECISION_LOW);
+    givensAnnihilateElement<double>(PRECISION_HIGH);
 }
 
 
@@ -1518,10 +1423,9 @@ void givensAnnihilateCorrectness(T epsilon) {
 
 }
 
-TEST_F(GivensAnnihilatorTest, givensAnnihilateCorrectness
-) {
-givensAnnihilateCorrectness<double>(1e-14);
-givensAnnihilateCorrectness<float>(1e-12);
+TEST_F(GivensAnnihilatorTest, givensAnnihilateCorrectness) {
+    givensAnnihilateCorrectness<double>(1e-14);
+    givensAnnihilateCorrectness<float>(1e-12);
 }
 
 

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -123,7 +123,7 @@ TEMPLATE_WITH_TYPE_T
 void tensorMoveConstructor() {
     DTensor<T> zero(2, 3, 4, true);
     DTensor<T> x(std::move(zero));
-    DTensor<T> y(DTensor < T > {100, 10, 1000});
+    DTensor<T> y(DTensor<T> {100, 10, 1000});
 }
 
 TEST_F(TensorTest, tensorMoveConstructor) {

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -26,7 +26,7 @@ protected:
 
 TEMPLATE_WITH_TYPE_T
 void tensorConstructionZero() {
-    DTensor<T> zero(2, 3, 4, true);
+    DTensor <T> zero(2, 3, 4, true);
     EXPECT_EQ(2, zero.numRows());
     EXPECT_EQ(3, zero.numCols());
     EXPECT_EQ(4, zero.numMats());
@@ -36,10 +36,14 @@ void tensorConstructionZero() {
     EXPECT_EQ(expectedResult, zeroDown);
 }
 
-TEST_F(TensorTest, tensorConstructionZero) {
-    tensorConstructionZero<float>();
-    tensorConstructionZero<double>();
-    tensorConstructionZero<int>();
+TEST_F(TensorTest, tensorConstructionZero
+) {
+tensorConstructionZero<float>();
+
+tensorConstructionZero<double>();
+
+tensorConstructionZero<int>();
+
 }
 
 /* ---------------------------------------
@@ -65,21 +69,21 @@ void tensorConstructionStorageMode() {
     std::vector<T> Rm = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::vector<T> hostData(rows * cols * mats);
     // test constructor
-    DTensor<T> testCm(Cm, rows, cols, mats, columnMajor);
-    DTensor<T> testRm(Rm, rows, cols, mats, rowMajor);
+    DTensor <T> testCm(Cm, rows, cols, mats, columnMajor);
+    DTensor <T> testRm(Rm, rows, cols, mats, rowMajor);
     testCm.download(hostData);
     EXPECT_EQ(Cm, hostData);
     testRm.download(hostData);
     EXPECT_EQ(Cm, hostData);
     // test .upload()
-    DTensor<T> testSplitCm(rows, cols, mats);
-    DTensor<T> ACm(testSplitCm, 2, 0, 0);
-    DTensor<T> BCm(testSplitCm, 2, 1, 1);
+    DTensor <T> testSplitCm(rows, cols, mats);
+    DTensor <T> ACm(testSplitCm, 2, 0, 0);
+    DTensor <T> BCm(testSplitCm, 2, 1, 1);
     ACm.upload(aCm, columnMajor);
     BCm.upload(bCm, columnMajor);
-    DTensor<T> testSplitRm(rows, cols, mats);
-    DTensor<T> ARm(testSplitRm, 2, 0, 0);
-    DTensor<T> BRm(testSplitRm, 2, 1, 1);
+    DTensor <T> testSplitRm(rows, cols, mats);
+    DTensor <T> ARm(testSplitRm, 2, 0, 0);
+    DTensor <T> BRm(testSplitRm, 2, 1, 1);
     ARm.upload(aRm, rowMajor);
     BRm.upload(bRm, rowMajor);
     testSplitCm.download(hostData);
@@ -88,10 +92,14 @@ void tensorConstructionStorageMode() {
     EXPECT_EQ(Cm, hostData);
 }
 
-TEST_F(TensorTest, tensorConstructionStorageMode) {
-    tensorConstructionStorageMode<float>();
-    tensorConstructionStorageMode<double>();
-    tensorConstructionStorageMode<int>();
+TEST_F(TensorTest, tensorConstructionStorageMode
+) {
+tensorConstructionStorageMode<float>();
+
+tensorConstructionStorageMode<double>();
+
+tensorConstructionStorageMode<int>();
+
 }
 
 /* ---------------------------------------
@@ -109,10 +117,14 @@ void randomTensorCreation() {
     EXPECT_TRUE(rEle >= -1 && rEle <= 1);
 }
 
-TEST_F(TensorTest, randomTensorCreation) {
-    randomTensorCreation<float>();
-    randomTensorCreation<double>();
-    randomTensorCreation<int>();
+TEST_F(TensorTest, randomTensorCreation
+) {
+randomTensorCreation<float>();
+
+randomTensorCreation<double>();
+
+randomTensorCreation<int>();
+
 }
 
 /* ---------------------------------------
@@ -121,17 +133,23 @@ TEST_F(TensorTest, randomTensorCreation) {
 
 TEMPLATE_WITH_TYPE_T
 void tensorMoveConstructor() {
-    DTensor<T> zero(2, 3, 4, true);
-    DTensor<T> x(std::move(zero));
-    DTensor<T> y(DTensor<T>{100, 10, 1000});
+    DTensor <T> zero(2, 3, 4, true);
+    DTensor <T> x(std::move(zero));
+    DTensor <T> y(DTensor < T > {100, 10, 1000});
 }
 
-TEST_F(TensorTest, tensorMoveConstructor) {
-    tensorMoveConstructor<float>();
-    tensorMoveConstructor<double>();
-    tensorMoveConstructor<int>();
-    tensorMoveConstructor<int *>();
-    tensorMoveConstructor<double *>();
+TEST_F(TensorTest, tensorMoveConstructor
+) {
+tensorMoveConstructor<float>();
+
+tensorMoveConstructor<double>();
+
+tensorMoveConstructor<int>();
+
+tensorMoveConstructor<int *>();
+
+tensorMoveConstructor<double *>();
+
 }
 
 /* ---------------------------------------
@@ -142,17 +160,21 @@ TEST_F(TensorTest, tensorMoveConstructor) {
 TEMPLATE_WITH_TYPE_T
 void tensorConstructionFromVector() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
     EXPECT_EQ(2, tenz.numRows());
     EXPECT_EQ(3, tenz.numCols());
     EXPECT_EQ(4, tenz.numMats());
     EXPECT_EQ(2 * 3 * 4, tenz.numEl());
 }
 
-TEST_F(TensorTest, tensorConstructionFromVector) {
-    tensorConstructionFromVector<float>();
-    tensorConstructionFromVector<double>();
-    tensorConstructionFromVector<int>();
+TEST_F(TensorTest, tensorConstructionFromVector
+) {
+tensorConstructionFromVector<float>();
+
+tensorConstructionFromVector<double>();
+
+tensorConstructionFromVector<int>();
+
 }
 
 /* ---------------------------------------
@@ -162,8 +184,8 @@ TEST_F(TensorTest, tensorConstructionFromVector) {
 TEMPLATE_WITH_TYPE_T
 void tensorCopyConstructor() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
-    DTensor<T> tenzCp(tenz);
+    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor <T> tenzCp(tenz);
     EXPECT_EQ(2, tenzCp.numRows());
     EXPECT_EQ(3, tenzCp.numCols());
     EXPECT_EQ(4, tenzCp.numMats());
@@ -174,10 +196,14 @@ void tensorCopyConstructor() {
     EXPECT_NE(tenz.raw(), tenzCp.raw());
 }
 
-TEST_F(TensorTest, tensorCopyConstructor) {
-    tensorCopyConstructor<float>();
-    tensorCopyConstructor<double>();
-    tensorCopyConstructor<int>();
+TEST_F(TensorTest, tensorCopyConstructor
+) {
+tensorCopyConstructor<float>();
+
+tensorCopyConstructor<double>();
+
+tensorCopyConstructor<int>();
+
 }
 
 /* ---------------------------------------
@@ -188,18 +214,22 @@ TEST_F(TensorTest, tensorCopyConstructor) {
 TEMPLATE_WITH_TYPE_T
 void tensorSlicingConstructorAxis2() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tens(data, 2, 3, 4);
-    DTensor<T> tensSlice(tens, 2, 0, 1); // matrices #0 and #1
+    DTensor <T> tens(data, 2, 3, 4);
+    DTensor <T> tensSlice(tens, 2, 0, 1); // matrices #0 and #1
     EXPECT_EQ(2, tensSlice.numRows());
     EXPECT_EQ(3, tensSlice.numCols());
     EXPECT_EQ(2, tensSlice.numMats());
     EXPECT_EQ(tens.raw(), tensSlice.raw()); // it is indeed a slice
 }
 
-TEST_F(TensorTest, tensorSlicingConstructorAxis2) {
-    tensorSlicingConstructorAxis2<float>();
-    tensorSlicingConstructorAxis2<double>();
-    tensorSlicingConstructorAxis2<int>();
+TEST_F(TensorTest, tensorSlicingConstructorAxis2
+) {
+tensorSlicingConstructorAxis2<float>();
+
+tensorSlicingConstructorAxis2<double>();
+
+tensorSlicingConstructorAxis2<int>();
+
 }
 
 /* ---------------------------------------
@@ -210,8 +240,8 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis2) {
 TEMPLATE_WITH_TYPE_T
 void tensorSlicingConstructorAxis1() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
-    DTensor<T> tenzSlice(tenz, 1, 1, 2); // columns from 1 to 2
+    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor <T> tenzSlice(tenz, 1, 1, 2); // columns from 1 to 2
     EXPECT_EQ(2, tenzSlice.numRows());
     EXPECT_EQ(2, tenzSlice.numCols());
     EXPECT_EQ(1, tenzSlice.numMats());
@@ -221,10 +251,14 @@ void tensorSlicingConstructorAxis1() {
     EXPECT_EQ(expected, tenzSliceDown);
 }
 
-TEST_F(TensorTest, tensorSlicingConstructorAxis1) {
-    tensorSlicingConstructorAxis1<float>();
-    tensorSlicingConstructorAxis1<double>();
-    tensorSlicingConstructorAxis1<int>();
+TEST_F(TensorTest, tensorSlicingConstructorAxis1
+) {
+tensorSlicingConstructorAxis1<float>();
+
+tensorSlicingConstructorAxis1<double>();
+
+tensorSlicingConstructorAxis1<int>();
+
 }
 
 /* ---------------------------------------
@@ -235,8 +269,8 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis1) {
 TEMPLATE_WITH_TYPE_T
 void tensorSlicingConstructorAxis0() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
-    DTensor<T> tenzSlice(tenz, 0, 2, 3); // elements 2..3
+    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor <T> tenzSlice(tenz, 0, 2, 3); // elements 2..3
     EXPECT_EQ(2, tenzSlice.numRows());
     EXPECT_EQ(1, tenzSlice.numCols());
     EXPECT_EQ(1, tenzSlice.numMats());
@@ -246,10 +280,14 @@ void tensorSlicingConstructorAxis0() {
     EXPECT_EQ(expected, tenzSliceDown);
 }
 
-TEST_F(TensorTest, tensorSlicingConstructorAxis0) {
-    tensorSlicingConstructorAxis0<float>();
-    tensorSlicingConstructorAxis0<double>();
-    tensorSlicingConstructorAxis0<int>();
+TEST_F(TensorTest, tensorSlicingConstructorAxis0
+) {
+tensorSlicingConstructorAxis0<float>();
+
+tensorSlicingConstructorAxis0<double>();
+
+tensorSlicingConstructorAxis0<int>();
+
 }
 
 /* ---------------------------------------
@@ -259,7 +297,7 @@ TEST_F(TensorTest, tensorSlicingConstructorAxis0) {
 TEMPLATE_WITH_TYPE_T
 void tensorUpload() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(2, 3, 4);
+    DTensor <T> tenz(2, 3, 4);
     tenz.upload(data);
     EXPECT_EQ(2, tenz.numRows());
     EXPECT_EQ(3, tenz.numCols());
@@ -269,10 +307,14 @@ void tensorUpload() {
     EXPECT_EQ(8, tenz(1, 2, 3));
 }
 
-TEST_F(TensorTest, tensorUpload) {
-    tensorUpload<float>();
-    tensorUpload<double>();
-    tensorUpload<int>();
+TEST_F(TensorTest, tensorUpload
+) {
+tensorUpload<float>();
+
+tensorUpload<double>();
+
+tensorUpload<int>();
+
 }
 
 /* ---------------------------------------
@@ -282,9 +324,9 @@ TEST_F(TensorTest, tensorUpload) {
 TEMPLATE_WITH_TYPE_T
 void tensorDeviceCopyTo() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
-    DTensor<T> other(2, 3, 5, true);
-    DTensor<T> z(other, 2, 1, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor <T> other(2, 3, 5, true);
+    DTensor <T> z(other, 2, 1, 4);
     tenz.deviceCopyTo(z);
     std::vector<T> expected = {0, 0, 0, 0, 0, 0,
                                1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 10, 5, 4, 3, 2, 1, -1, 4, 3, 4, 3, 4, 8};
@@ -293,10 +335,42 @@ void tensorDeviceCopyTo() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorDeviceCopyTo) {
-    tensorDeviceCopyTo<float>();
-    tensorDeviceCopyTo<double>();
-    tensorDeviceCopyTo<int>();
+TEST_F(TensorTest, tensorDeviceCopyTo
+) {
+tensorDeviceCopyTo<float>();
+
+tensorDeviceCopyTo<double>();
+
+tensorDeviceCopyTo<int>();
+
+}
+
+
+/* ---------------------------------------
+ * Tensor: Frobenius dot product
+ * --------------------------------------- */
+
+TEMPLATE_WITH_TYPE_T
+void tensorReshape() {
+    size_t m = 5, n = 10, k = 3;
+    DTensor <T> a = DTensor<T>::createRandomTensor(m, n, k, -1, 1); // dim = (m, n, k)
+    ASSERT_EQ(m, a.numRows());
+    ASSERT_EQ(n, a.numCols());
+    ASSERT_EQ(k, a.numMats());
+    a.reshape(m, k, n); // dim = (m, k, n)
+    ASSERT_EQ(m, a.numRows());
+    ASSERT_EQ(k, a.numCols());
+    ASSERT_EQ(n, a.numMats());
+    a.reshape(k, n, m); // dim = (k, n, m)
+    ASSERT_EQ(k, a.numRows());
+    ASSERT_EQ(n, a.numCols());
+    ASSERT_EQ(m, a.numMats());
+}
+
+TEST_F(TensorTest, tensorReshape) {
+    tensorReshape<float>();
+    tensorReshape<double>();
+    tensorReshape<int>();
 }
 
 /* ---------------------------------------
@@ -308,20 +382,21 @@ void tensorDotF(T epsilon) {
     // as vectors
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor<T> vecA(dataA, dataA.size());
-    DTensor<T> vecB(dataB, dataB.size());
+    DTensor <T> vecA(dataA, dataA.size());
+    DTensor <T> vecB(dataB, dataB.size());
     T dotVector = vecA.dotF(vecB);
     EXPECT_EQ(604, dotVector);  // from MATLAB
     // as matrices
-    DTensor<T> tenA(dataA, 2, 3, 4);
-    DTensor<T> tenB(dataB, 2, 3, 4);
+    DTensor <T> tenA(dataA, 2, 3, 4);
+    DTensor <T> tenB(dataB, 2, 3, 4);
     T dotTensor = tenA.dotF(tenB);
     EXPECT_EQ(604, dotTensor);  // from MATLAB
 }
 
-TEST_F(TensorTest, tensorDotF) {
-    tensorDotF<float>(PRECISION_LOW);
-    tensorDotF<double>(PRECISION_HIGH);
+TEST_F(TensorTest, tensorDotF
+) {
+tensorDotF<float>(PRECISION_LOW);
+tensorDotF<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -331,13 +406,14 @@ TEST_F(TensorTest, tensorDotF) {
 TEMPLATE_WITH_TYPE_T
 void tensorNormF(T epsilon) {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
     EXPECT_NEAR(26.153393661244042, tenz.normF(), epsilon); // from MATLAB
 }
 
-TEST_F(TensorTest, tensorNormF) {
-    tensorNormF<float>(PRECISION_LOW);
-    tensorNormF<double>(PRECISION_HIGH);
+TEST_F(TensorTest, tensorNormF
+) {
+tensorNormF<float>(PRECISION_LOW);
+tensorNormF<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -348,13 +424,16 @@ TEST_F(TensorTest, tensorNormF) {
 TEMPLATE_WITH_TYPE_T
 void tensorSumAbs() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
     EXPECT_NEAR(112, tenz.sumAbs(), PRECISION_HIGH); // from MATLAB
 }
 
-TEST_F(TensorTest, tensorSumAbs) {
-    tensorSumAbs<float>();
-    tensorSumAbs<double>();
+TEST_F(TensorTest, tensorSumAbs
+) {
+tensorSumAbs<float>();
+
+tensorSumAbs<double>();
+
 }
 
 /* ---------------------------------------
@@ -364,14 +443,17 @@ TEST_F(TensorTest, tensorSumAbs) {
 TEMPLATE_WITH_TYPE_T
 void tensorMax() {
     std::vector<T> data = TENSOR_DATA_234AMB;
-    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
     T m = tenz.maxAbs();
     EXPECT_EQ(27, m);
 }
 
-TEST_F(TensorTest, tensorMax) {
-    tensorMax<float>();
-    tensorMax<double>();
+TEST_F(TensorTest, tensorMax
+) {
+tensorMax<float>();
+
+tensorMax<double>();
+
 }
 
 /* ---------------------------------------
@@ -381,14 +463,17 @@ TEST_F(TensorTest, tensorMax) {
 TEMPLATE_WITH_TYPE_T
 void tensorMin() {
     std::vector<T> data = TENSOR_DATA_234AMB;
-    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
     T m = tenz.minAbs();
     EXPECT_EQ(0, m);
 }
 
-TEST_F(TensorTest, tensorMin) {
-    tensorMin<float>();
-    tensorMin<double>();
+TEST_F(TensorTest, tensorMin
+) {
+tensorMin<float>();
+
+tensorMin<double>();
+
 }
 
 /* ---------------------------------------
@@ -421,9 +506,10 @@ void tensorRightGivens(T epsilon) {
     }
 }
 
-TEST_F(TensorTest, tensorRightGivens) {
-    tensorRightGivens<float>(PRECISION_LOW);
-    tensorRightGivens<double>(PRECISION_HIGH);
+TEST_F(TensorTest, tensorRightGivens
+) {
+tensorRightGivens<float>(PRECISION_LOW);
+tensorRightGivens<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -458,9 +544,10 @@ void tensorLeftGivens(T epsilon) {
     }
 }
 
-TEST_F(TensorTest, tensorLeftGivens) {
-    tensorLeftGivens<float>(1e-10);
-    tensorLeftGivens<double>(1e-14);
+TEST_F(TensorTest, tensorLeftGivens
+) {
+tensorLeftGivens<float>(1e-10);
+tensorLeftGivens<double>(1e-14);
 }
 
 /* ---------------------------------------
@@ -471,16 +558,20 @@ TEST_F(TensorTest, tensorLeftGivens) {
 TEMPLATE_WITH_TYPE_T
 void tensorBracketOperator() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
     EXPECT_EQ(1, tenz(0, 0, 0));
     EXPECT_EQ(3, tenz(0, 1, 2));
     EXPECT_EQ(8, tenz(1, 2, 3));
 }
 
-TEST_F(TensorTest, tensorBracketOperator) {
-    tensorBracketOperator<float>();
-    tensorBracketOperator<double>();
-    tensorBracketOperator<int>();
+TEST_F(TensorTest, tensorBracketOperator
+) {
+tensorBracketOperator<float>();
+
+tensorBracketOperator<double>();
+
+tensorBracketOperator<int>();
+
 }
 
 /* ---------------------------------------
@@ -490,8 +581,8 @@ TEST_F(TensorTest, tensorBracketOperator) {
 TEMPLATE_WITH_TYPE_T
 void tensorAssignmentOperator() {
     std::vector<T> data = TENSOR_DATA_234A;
-    DTensor<T> tenz(data, 2, 3, 4);
-    DTensor<T> other;
+    DTensor <T> tenz(data, 2, 3, 4);
+    DTensor <T> other;
     other = tenz;
     EXPECT_EQ(tenz.raw(), other.raw());
     EXPECT_EQ(2, other.numRows());
@@ -499,10 +590,14 @@ void tensorAssignmentOperator() {
     EXPECT_EQ(4, other.numMats());
 }
 
-TEST_F(TensorTest, tensorAssignmentOperator) {
-    tensorAssignmentOperator<float>();
-    tensorAssignmentOperator<double>();
-    tensorAssignmentOperator<int>();
+TEST_F(TensorTest, tensorAssignmentOperator
+) {
+tensorAssignmentOperator<float>();
+
+tensorAssignmentOperator<double>();
+
+tensorAssignmentOperator<int>();
+
 }
 
 /* ---------------------------------------
@@ -514,16 +609,19 @@ void tensorTimesEqualsScalar() {
     std::vector<T> data = TENSOR_DATA_234A;
     std::vector<T> dataTimes3 = {3, 6, 9, 12, 15, 18, 21, 24, 27, 24, 21, 30, 15, 12, 9, 6, 3, -3, 12, 9, 12, 9, 12,
                                  24};
-    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
     tenz *= 3.0;
     std::vector<T> actual;
     tenz.download(actual);
     EXPECT_EQ(dataTimes3, actual);
 }
 
-TEST_F(TensorTest, tensorTimesEqualsScalar) {
-    tensorTimesEqualsScalar<float>();
-    tensorTimesEqualsScalar<double>();
+TEST_F(TensorTest, tensorTimesEqualsScalar
+) {
+tensorTimesEqualsScalar<float>();
+
+tensorTimesEqualsScalar<double>();
+
 }
 
 /* ---------------------------------------
@@ -535,16 +633,19 @@ void tensorTimesScalar() {
     std::vector<T> data = TENSOR_DATA_234A;
     std::vector<T> dataTimes3 = {3, 6, 9, 12, 15, 18, 21, 24, 27, 24, 21, 30, 15, 12, 9, 6, 3, -3, 12, 9, 12, 9, 12,
                                  24};
-    DTensor<T> tenz(data, 2, 3, 4);
+    DTensor <T> tenz(data, 2, 3, 4);
     auto tripleTensor = 3.0 * tenz;
     std::vector<T> actual;
     tripleTensor.download(actual);
     EXPECT_EQ(dataTimes3, actual);
 }
 
-TEST_F(TensorTest, tensorTimesScalar) {
-    tensorTimesScalar<float>();
-    tensorTimesScalar<double>();
+TEST_F(TensorTest, tensorTimesScalar
+) {
+tensorTimesScalar<float>();
+
+tensorTimesScalar<double>();
+
 }
 
 /* ---------------------------------------
@@ -555,8 +656,8 @@ TEMPLATE_WITH_TYPE_T
 void tensorPlusEqualsTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor<T> A(dataA, 2, 3, 4);
-    DTensor<T> B(dataB, 2, 3, 4);
+    DTensor <T> A(dataA, 2, 3, 4);
+    DTensor <T> B(dataB, 2, 3, 4);
     A += B;
     std::vector<T> expected = TENSOR_DATA_234APB;
     std::vector<T> actual;
@@ -564,9 +665,12 @@ void tensorPlusEqualsTensor() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorPlusEqualsTensor) {
-    tensorPlusEqualsTensor<float>();
-    tensorPlusEqualsTensor<double>();
+TEST_F(TensorTest, tensorPlusEqualsTensor
+) {
+tensorPlusEqualsTensor<float>();
+
+tensorPlusEqualsTensor<double>();
+
 }
 
 /* ---------------------------------------
@@ -577,8 +681,8 @@ TEMPLATE_WITH_TYPE_T
 void tensorMinusEqualsTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor<T> A(dataA, 2, 3, 4);
-    DTensor<T> B(dataB, 2, 3, 4);
+    DTensor <T> A(dataA, 2, 3, 4);
+    DTensor <T> B(dataB, 2, 3, 4);
     A -= B;
     std::vector<T> expected = TENSOR_DATA_234AMB;
     std::vector<T> actual;
@@ -586,9 +690,12 @@ void tensorMinusEqualsTensor() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorMinusEqualsTensor) {
-    tensorMinusEqualsTensor<float>();
-    tensorMinusEqualsTensor<double>();
+TEST_F(TensorTest, tensorMinusEqualsTensor
+) {
+tensorMinusEqualsTensor<float>();
+
+tensorMinusEqualsTensor<double>();
+
 }
 
 /* ---------------------------------------
@@ -599,18 +706,21 @@ TEMPLATE_WITH_TYPE_T
 void tensorPlusTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor<T> A(dataA, 2, 3, 4);
-    DTensor<T> B(dataB, 2, 3, 4);
-    DTensor<T> C = A + B;
+    DTensor <T> A(dataA, 2, 3, 4);
+    DTensor <T> B(dataB, 2, 3, 4);
+    DTensor <T> C = A + B;
     std::vector<T> expected = TENSOR_DATA_234APB;
     std::vector<T> actual;
     C.download(actual);
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorPlusTensor) {
-    tensorPlusTensor<float>();
-    tensorPlusTensor<double>();
+TEST_F(TensorTest, tensorPlusTensor
+) {
+tensorPlusTensor<float>();
+
+tensorPlusTensor<double>();
+
 }
 
 /* ---------------------------------------
@@ -621,18 +731,21 @@ TEMPLATE_WITH_TYPE_T
 void tensorMinusTensor() {
     std::vector<T> dataA = TENSOR_DATA_234A;
     std::vector<T> dataB = TENSOR_DATA_234B;
-    DTensor<T> A(dataA, 2, 3, 4);
-    DTensor<T> B(dataB, 2, 3, 4);
-    DTensor<T> C = A - B;
+    DTensor <T> A(dataA, 2, 3, 4);
+    DTensor <T> B(dataB, 2, 3, 4);
+    DTensor <T> C = A - B;
     std::vector<T> expected = TENSOR_DATA_234AMB;
     std::vector<T> actual;
     C.download(actual);
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorMinusTensor) {
-    tensorMinusTensor<float>();
-    tensorMinusTensor<double>();
+TEST_F(TensorTest, tensorMinusTensor
+) {
+tensorMinusTensor<float>();
+
+tensorMinusTensor<double>();
+
 }
 
 /* ---------------------------------------
@@ -647,9 +760,9 @@ void tensorAddAB() {
     std::vector<T> bData = {6, 5, 4, 3, 2, 1,
                             7, 6, 5, 4, 3, 2,
                             1, 2, 1, 5, -6, 8};
-    DTensor<T> A(aData, 2, 3, 3);
-    DTensor<T> B(bData, 3, 2, 3);
-    DTensor<T> C(2, 2, 3, true);
+    DTensor <T> A(aData, 2, 3, 3);
+    DTensor <T> B(bData, 3, 2, 3);
+    DTensor <T> C(2, 2, 3, true);
     C.addAB(A, B);
     std::vector<T> expected = {41, 56, 14, 20, 158, 176, 77, 86, 60, 64, 111, 118};
     std::vector<T> actual;
@@ -657,9 +770,12 @@ void tensorAddAB() {
     EXPECT_EQ(expected, actual);
 }
 
-TEST_F(TensorTest, tensorAddAB) {
-    tensorAddAB<double>();
-    tensorAddAB<float>();
+TEST_F(TensorTest, tensorAddAB
+) {
+tensorAddAB<double>();
+
+tensorAddAB<float>();
+
 }
 
 /* ---------------------------------------
@@ -674,23 +790,26 @@ void tensorGetRows() {
                             5., 6., 7.,
                             8., 9., 10.,
                             11., 12., 13};
-    DTensor<T> A(aData, 3, 3, 2);
-    DTensor<T> Ar0 = A.getRows(1, 1, 0);
+    DTensor <T> A(aData, 3, 3, 2);
+    DTensor <T> Ar0 = A.getRows(1, 1, 0);
     std::vector<T> expected0 = {25., 720., -1.};
     std::vector<T> actual0(3);
     Ar0.download(actual0);
     EXPECT_EQ(expected0, actual0);
 
-    DTensor<T> Ar1 = A.getRows(1, 2, 1);
+    DTensor <T> Ar1 = A.getRows(1, 2, 1);
     std::vector<T> expected1 = {6., 7., 9., 10., 12., 13.};
     std::vector<T> actual1(6);
     Ar1.download(actual1);
     EXPECT_EQ(expected1, actual1);
 }
 
-TEST_F(TensorTest, tensorGetRows) {
-    tensorGetRows<float>();
-    tensorGetRows<double>();
+TEST_F(TensorTest, tensorGetRows
+) {
+tensorGetRows<float>();
+
+tensorGetRows<double>();
+
 }
 
 
@@ -701,8 +820,8 @@ TEST_F(TensorTest, tensorGetRows) {
 TEMPLATE_WITH_TYPE_T
 void tensorTranspose() {
     std::vector<T> aData = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    DTensor<T> A(aData, 3, 2, 2);
-    DTensor<T> Atranspose = A.tr();
+    DTensor <T> A(aData, 3, 2, 2);
+    DTensor <T> Atranspose = A.tr();
     EXPECT_EQ(2, Atranspose.numRows());
     EXPECT_EQ(3, Atranspose.numCols());
     EXPECT_EQ(2, Atranspose.numMats());
@@ -713,9 +832,12 @@ void tensorTranspose() {
 
 }
 
-TEST_F(TensorTest, tensorTranspose) {
-    tensorTranspose<float>();
-    tensorTranspose<double>();
+TEST_F(TensorTest, tensorTranspose
+) {
+tensorTranspose<float>();
+
+tensorTranspose<double>();
+
 }
 
 /* ================================================================================================
@@ -742,21 +864,22 @@ void tensorLeastSquares1(T epsilon) {
                             6, 8,
                             -9, 20};
     std::vector<T> bData = {1, 1, -1, 2, 30, -80};
-    DTensor<T> A0(aData, 2, 2, 3);
-    DTensor<T> A(A0);
-    DTensor<T> B(bData, 2, 1, 3);
-    DTensor<T> sol(B);
+    DTensor <T> A0(aData, 2, 2, 3);
+    DTensor <T> A(A0);
+    DTensor <T> B(bData, 2, 1, 3);
+    DTensor <T> sol(B);
     A0.leastSquaresBatched(sol);
-    DTensor<T> C(2, 1, 3);
+    DTensor <T> C(2, 1, 3);
     C.addAB(A, sol);
     C -= B;
     T nrmErr = C.normF();
     EXPECT_LT(nrmErr, epsilon);
 }
 
-TEST_F(LeastSquaresTest, tensorLS1) {
-    tensorLeastSquares1<float>(PRECISION_LOW);
-    tensorLeastSquares1<double>(PRECISION_HIGH);
+TEST_F(LeastSquaresTest, tensorLS1
+) {
+tensorLeastSquares1<float>(PRECISION_LOW);
+tensorLeastSquares1<double>(PRECISION_HIGH);
 }
 
 
@@ -780,8 +903,8 @@ void singularValuesComputation(float epsilon) {
     std::vector<T> bData = {1, 6, 6, 6, 6, 6, 6, 6,
                             2, 7, 7, 7, 7, 7, 7, 7,
                             3, 8, 8, 8, 8, 8, 8, 8,};
-    DTensor<T> B(bData, 8, 3);
-    Svd<T> svd(B, true, false);
+    DTensor <T> B(bData, 8, 3);
+    Svd <T> svd(B, true, false);
     EXPECT_EQ(true, svd.factorise());
     auto S = svd.singularValues();
     EXPECT_NEAR(32.496241123753592, S(0), epsilon); // value from MATLAB
@@ -791,9 +914,10 @@ void singularValuesComputation(float epsilon) {
     EXPECT_TRUE(U.has_value());
 }
 
-TEST_F(SvdTest, singularValuesComputation) {
-    singularValuesComputation<float>(PRECISION_LOW);
-    singularValuesComputation<double>(PRECISION_HIGH);
+TEST_F(SvdTest, singularValuesComputation
+) {
+singularValuesComputation<float>(PRECISION_LOW);
+singularValuesComputation<double>(PRECISION_HIGH);
 }
 
 
@@ -806,15 +930,15 @@ void singularValuesMemory(float epsilon) {
     std::vector<T> bData = {1, 6, 6, 6, 6, 6, 6, 6,
                             2, 7, 7, 7, 7, 7, 7, 7,
                             3, 8, 8, 8, 8, 8, 8, 8,};
-    DTensor<T> B(bData, 8, 3);
-    Svd<T> svd(B, true, false);
+    DTensor <T> B(bData, 8, 3);
+    Svd <T> svd(B, true, false);
     EXPECT_EQ(true, svd.factorise());
-    DTensor<T> const &v1 = svd.rightSingularVectors();
-    DTensor<T> const &v2 = svd.rightSingularVectors();
+    DTensor <T> const &v1 = svd.rightSingularVectors();
+    DTensor <T> const &v2 = svd.rightSingularVectors();
     EXPECT_EQ(&v1, &v2);
     EXPECT_EQ(v1.raw(), v2.raw());
-    DTensor<T> const &s1 = svd.singularValues();
-    DTensor<T> const &s2 = svd.singularValues();
+    DTensor <T> const &s1 = svd.singularValues();
+    DTensor <T> const &s2 = svd.singularValues();
     EXPECT_EQ(&s1, &s2);
     EXPECT_EQ(s1.raw(), s2.raw());
     auto u1 = svd.leftSingularVectors().value();
@@ -823,9 +947,10 @@ void singularValuesMemory(float epsilon) {
     EXPECT_EQ(u1->raw(), u2->raw());
 }
 
-TEST_F(SvdTest, singularValuesMemory) {
-    singularValuesMemory<float>(PRECISION_LOW);
-    singularValuesMemory<double>(PRECISION_HIGH);
+TEST_F(SvdTest, singularValuesMemory
+) {
+singularValuesMemory<float>(PRECISION_LOW);
+singularValuesMemory<double>(PRECISION_HIGH);
 }
 
 
@@ -835,11 +960,11 @@ TEST_F(SvdTest, singularValuesMemory) {
 TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void singularValuesMultipleMatrices(float epsilon) {
     std::vector<T> aData = {1, 2, 3, 4, 5, 6, 1, 1, 1, 2, 2, 2, 0, 0, 0, 0, 0, 1};
-    DTensor<T> A(aData, 3, 2, 3);
-    Svd<T> svd(A, true); // do compute U (A will be destroyed)
+    DTensor <T> A(aData, 3, 2, 3);
+    Svd <T> svd(A, true); // do compute U (A will be destroyed)
     svd.factorise();
-    DTensor<T> const &S = svd.singularValues();
-    DTensor<T> const &V = svd.rightSingularVectors();
+    DTensor <T> const &S = svd.singularValues();
+    DTensor <T> const &V = svd.rightSingularVectors();
     auto Uopt = svd.leftSingularVectors();
     auto U = Uopt.value();
     std::vector<T> expected_v = {-0.386317703118612, -0.922365780077058, -0.922365780077058, 0.386317703118612,
@@ -869,9 +994,10 @@ void singularValuesMultipleMatrices(float epsilon) {
 
 }
 
-TEST_F(SvdTest, singularValuesMultipleMatrices) {
-    singularValuesMultipleMatrices<float>(10 * PRECISION_LOW); // SVD with float performs quite poorly
-    singularValuesMultipleMatrices<double>(PRECISION_HIGH);
+TEST_F(SvdTest, singularValuesMultipleMatrices
+) {
+singularValuesMultipleMatrices<float>(10 * PRECISION_LOW); // SVD with float performs quite poorly
+singularValuesMultipleMatrices<double>(PRECISION_HIGH);
 }
 
 
@@ -884,9 +1010,9 @@ void singularValuesRankMultipleMatrices(float epsilon) {
     std::vector<T> aData = {1, 4, 7, 10, 2, 5, 8, 11, 3, 6, 9, 0,
                             1, 4, 7, 10, 2, 5, 8, 11, 3, 6, 9, 12,
                             1, 2, 3, 4, 2, 4, 6, 8, 3, 6, 9, 12};
-    DTensor<T> A(aData, 4, 3, 3);
+    DTensor <T> A(aData, 4, 3, 3);
 
-    Svd<T> svd(A);
+    Svd <T> svd(A);
     svd.factorise();
     auto rank = svd.rank(epsilon);
     EXPECT_EQ(3, rank(0, 0, 0));
@@ -894,9 +1020,10 @@ void singularValuesRankMultipleMatrices(float epsilon) {
     EXPECT_EQ(1, rank(0, 0, 2));
 }
 
-TEST_F(SvdTest, singularValuesRankMultipleMatrices) {
-    singularValuesRankMultipleMatrices<float>(PRECISION_LOW); // SVD with float performs quite poorly
-    singularValuesRankMultipleMatrices<double>(PRECISION_HIGH);
+TEST_F(SvdTest, singularValuesRankMultipleMatrices
+) {
+singularValuesRankMultipleMatrices<float>(PRECISION_LOW); // SVD with float performs quite poorly
+singularValuesRankMultipleMatrices<double>(PRECISION_HIGH);
 }
 
 /* ================================================================================================
@@ -919,17 +1046,18 @@ void choleskyFactorisation(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor<T> A(aData, 3, 3, 1);
-    CholeskyFactoriser<T> chol(A);
+    DTensor <T> A(aData, 3, 3, 1);
+    CholeskyFactoriser <T> chol(A);
     chol.factorise();
     EXPECT_NEAR(3.162277660168380, A(0, 0), epsilon);
     EXPECT_NEAR(-0.361403161162101, A(2, 1), epsilon);
     EXPECT_NEAR(5.382321781081287, A(2, 2), epsilon);
 }
 
-TEST_F(CholeskyTest, choleskyFactorisation) {
-    choleskyFactorisation<float>(PRECISION_LOW);
-    choleskyFactorisation<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyFactorisation
+) {
+choleskyFactorisation<float>(PRECISION_LOW);
+choleskyFactorisation<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -941,14 +1069,14 @@ void choleskyFactorisationSolution(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor<T> A(aData, 3, 3, 1);
-    DTensor<T> L(A); // L = A
-    CholeskyFactoriser<T> chol(L);
+    DTensor <T> A(aData, 3, 3, 1);
+    DTensor <T> L(A); // L = A
+    CholeskyFactoriser <T> chol(L);
     chol.factorise();
 
     std::vector<T> bData = {-1., -3., 5.};
-    DTensor<T> rhs(bData, 3, 1, 1);
-    DTensor<T> sol(rhs);
+    DTensor <T> rhs(bData, 3, 1, 1);
+    DTensor <T> sol(rhs);
     chol.solve(sol);
 
     std::vector<T> expected = {-0.126805213103205, -0.128566396618528, 0.175061641423036};
@@ -956,15 +1084,16 @@ void choleskyFactorisationSolution(T epsilon) {
     sol.download(actual);
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);
 
-    DTensor<T> error = A * sol;
+    DTensor <T> error = A * sol;
     error -= rhs;
     EXPECT_TRUE(error.normF() < epsilon);
 
 }
 
-TEST_F(CholeskyTest, choleskyFactorisationSolution) {
-    choleskyFactorisationSolution<float>(PRECISION_LOW);
-    choleskyFactorisationSolution<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyFactorisationSolution
+) {
+choleskyFactorisationSolution<float>(PRECISION_LOW);
+choleskyFactorisationSolution<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -976,12 +1105,12 @@ void choleskyBatchFactorisation(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor<T> A(3, 3, 2);
-    DTensor<T> A0(A, 2, 0, 0);
-    DTensor<T> A1(A, 2, 1, 1);
+    DTensor <T> A(3, 3, 2);
+    DTensor <T> A0(A, 2, 0, 0);
+    DTensor <T> A1(A, 2, 1, 1);
     A0.upload(aData);
     A1.upload(aData);
-    CholeskyBatchFactoriser<T> chol(A);
+    CholeskyBatchFactoriser <T> chol(A);
     chol.factorise();
     // 0
     EXPECT_NEAR(3.162277660168380, A(0, 0, 0), epsilon);
@@ -993,9 +1122,10 @@ void choleskyBatchFactorisation(T epsilon) {
     EXPECT_NEAR(5.382321781081287, A(2, 2, 1), epsilon);
 }
 
-TEST_F(CholeskyTest, choleskyBatchFactorisation) {
-    choleskyBatchFactorisation<float>(PRECISION_LOW);
-    choleskyBatchFactorisation<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyBatchFactorisation
+) {
+choleskyBatchFactorisation<float>(PRECISION_LOW);
+choleskyBatchFactorisation<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1007,35 +1137,36 @@ void choleskyBatchFactorSolve(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor<T> A(3, 3, 2);
-    DTensor<T> A0(A, 2, 0, 0);
-    DTensor<T> A1(A, 2, 1, 1);
+    DTensor <T> A(3, 3, 2);
+    DTensor <T> A0(A, 2, 0, 0);
+    DTensor <T> A1(A, 2, 1, 1);
     A0.upload(aData);
     A1.upload(aData);
-    DTensor<T> L(A); // L = A
-    CholeskyBatchFactoriser<T> chol(L);
+    DTensor <T> L(A); // L = A
+    CholeskyBatchFactoriser <T> chol(L);
     chol.factorise();
     std::vector<T> bData = {-1., -3., 5.};
-    DTensor<T> rhs(3, 1, 2);
-    DTensor<T> rhs0(rhs, 2, 0, 0);
-    DTensor<T> rhs1(rhs, 2, 1, 1);
+    DTensor <T> rhs(3, 1, 2);
+    DTensor <T> rhs0(rhs, 2, 0, 0);
+    DTensor <T> rhs1(rhs, 2, 1, 1);
     rhs0.upload(bData);
     rhs1.upload(bData);
-    DTensor<T> sol(rhs);
+    DTensor <T> sol(rhs);
     chol.solve(sol);
     std::vector<T> expected = {-0.126805213103205, -0.128566396618528, 0.175061641423036};
     std::vector<T> actual(6);
     sol.download(actual);
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);  // 0
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i + 3], epsilon);  // 1
-    DTensor<T> error = A * sol;
+    DTensor <T> error = A * sol;
     error -= rhs;
     EXPECT_TRUE(error.normF() < epsilon);
 }
 
-TEST_F(CholeskyTest, choleskyBatchFactorSolve) {
-    choleskyBatchFactorSolve<float>(PRECISION_LOW);
-    choleskyBatchFactorSolve<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyBatchFactorSolve
+) {
+choleskyBatchFactorSolve<float>(PRECISION_LOW);
+choleskyBatchFactorSolve<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1047,42 +1178,43 @@ void choleskyBatchSolve(T epsilon) {
     std::vector<T> aData = {10.0, 2.0, 3.0,
                             2.0, 20.0, -1.0,
                             3.0, -1.0, 30.0};
-    DTensor<T> A(3, 3, 2);
-    DTensor<T> A0(A, 2, 0, 0);
-    DTensor<T> A1(A, 2, 1, 1);
+    DTensor <T> A(3, 3, 2);
+    DTensor <T> A0(A, 2, 0, 0);
+    DTensor <T> A1(A, 2, 1, 1);
     A0.upload(aData);
     A1.upload(aData);
     std::vector<T> lowData = {3.162277660168380, 0, 0,
                               0.632455532033676, 4.427188724235731, 0,
                               0.948683298050514, -0.361403161162101, 5.382321781081287};  // from matlab
-    DTensor<T> low(3, 3, 2);
-    DTensor<T> low0(low, 2, 0, 0);
-    DTensor<T> low1(low, 2, 1, 1);
+    DTensor <T> low(3, 3, 2);
+    DTensor <T> low0(low, 2, 0, 0);
+    DTensor <T> low1(low, 2, 1, 1);
     low0.upload(lowData, rowMajor);
     low1.upload(lowData, rowMajor);
-    DTensor<T> L(low);
-    CholeskyBatchFactoriser<T> chol(L, true);
+    DTensor <T> L(low);
+    CholeskyBatchFactoriser <T> chol(L, true);
     std::vector<T> bData = {-1., -3., 5.};
-    DTensor<T> rhs(3, 1, 2);
-    DTensor<T> rhs0(rhs, 2, 0, 0);
-    DTensor<T> rhs1(rhs, 2, 1, 1);
+    DTensor <T> rhs(3, 1, 2);
+    DTensor <T> rhs0(rhs, 2, 0, 0);
+    DTensor <T> rhs1(rhs, 2, 1, 1);
     rhs0.upload(bData);
     rhs1.upload(bData);
-    DTensor<T> sol(rhs);
+    DTensor <T> sol(rhs);
     chol.solve(sol);
     std::vector<T> expected = {-0.126805213103205, -0.128566396618528, 0.175061641423036};
     std::vector<T> actual(6);
     sol.download(actual);
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i], epsilon);  // 0
     for (size_t i = 0; i < 3; i++) EXPECT_NEAR(expected[i], actual[i + 3], epsilon);  // 1
-    DTensor<T> error = A * sol;
+    DTensor <T> error = A * sol;
     error -= rhs;
     EXPECT_TRUE(error.normF() < epsilon);
 }
 
-TEST_F(CholeskyTest, choleskyBatchSolve) {
-    choleskyBatchSolve<float>(PRECISION_LOW);
-    choleskyBatchSolve<double>(PRECISION_HIGH);
+TEST_F(CholeskyTest, choleskyBatchSolve
+) {
+choleskyBatchSolve<float>(PRECISION_LOW);
+choleskyBatchSolve<double>(PRECISION_HIGH);
 }
 
 
@@ -1105,15 +1237,15 @@ TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void qrFactorisation(T epsilon) {
     size_t nR = 4;
     size_t nC = 3;
-    DTensor<T> temp(nR, nC);
-    DTensor<T> A = DTensor<T>::createRandomTensor(nR, nC, 1, -100, 100);
-    QRFactoriser<T> qr(temp);
+    DTensor <T> temp(nR, nC);
+    DTensor <T> A = DTensor<T>::createRandomTensor(nR, nC, 1, -100, 100);
+    QRFactoriser <T> qr(temp);
     A.deviceCopyTo(temp);
     int status = qr.factorise();
     EXPECT_EQ(status, 0);
-    DTensor<T> Q(nR, nC);
-    DTensor<T> R(nC, nC, 1, true);
-    DTensor<T> QR(nR, nC);
+    DTensor <T> Q(nR, nC);
+    DTensor <T> R(nC, nC, 1, true);
+    DTensor <T> QR(nR, nC);
     status = qr.getQR(Q, R);
     EXPECT_EQ(status, 0);
     QR.addAB(Q, R);
@@ -1122,9 +1254,10 @@ void qrFactorisation(T epsilon) {
     EXPECT_NEAR(nrm, 0., epsilon);
 }
 
-TEST_F(QRTest, qrFactorisation) {
-    qrFactorisation<float>(PRECISION_LOW);
-    qrFactorisation<double>(PRECISION_HIGH);
+TEST_F(QRTest, qrFactorisation
+) {
+qrFactorisation<float>(PRECISION_LOW);
+qrFactorisation<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1136,15 +1269,15 @@ TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void qrFactorisationTall(T epsilon) {
     size_t nR = 20;
     size_t nC = 3;
-    DTensor<T> temp(nR, nC);
-    DTensor<T> A = DTensor<T>::createRandomTensor(nR, nC, 1, -100, 100);
-    QRFactoriser<T> qr(temp);
+    DTensor <T> temp(nR, nC);
+    DTensor <T> A = DTensor<T>::createRandomTensor(nR, nC, 1, -100, 100);
+    QRFactoriser <T> qr(temp);
     A.deviceCopyTo(temp);
     int status = qr.factorise();
     EXPECT_EQ(status, 0);
-    DTensor<T> Q(nR, nC);
-    DTensor<T> R(nC, nC, 1, true);
-    DTensor<T> QR(nR, nC);
+    DTensor <T> Q(nR, nC);
+    DTensor <T> R(nC, nC, 1, true);
+    DTensor <T> QR(nR, nC);
     status = qr.getQR(Q, R);
     EXPECT_EQ(status, 0);
     QR.addAB(Q, R);
@@ -1153,9 +1286,10 @@ void qrFactorisationTall(T epsilon) {
     EXPECT_NEAR(nrm, 0., epsilon);
 }
 
-TEST_F(QRTest, qrFactorisationTall) {
-    qrFactorisationTall<float>(PRECISION_LOW);
-    qrFactorisationTall<double>(PRECISION_HIGH);
+TEST_F(QRTest, qrFactorisationTall
+) {
+qrFactorisationTall<float>(PRECISION_LOW);
+qrFactorisationTall<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1166,7 +1300,7 @@ TEMPLATE_WITH_TYPE_T TEMPLATE_CONSTRAINT_REQUIRES_FPX
 void qrLeastSquares(T epsilon) {
     size_t nR = 4;
     size_t nC = 3;
-    DTensor<T> temp(nR, nC);
+    DTensor <T> temp(nR, nC);
     std::vector<T> vecA = {85.5638, -59.4001, -80.1992,
                            99.9464, 5.51393, 5.17935,
                            6.87488, -26.7536, 36.0914,
@@ -1175,12 +1309,12 @@ void qrLeastSquares(T epsilon) {
                            -48.5744,
                            43.4229,
                            -56.5081};  // Random vector
-    DTensor<T> A(vecA, nR, nC, 1, rowMajor);
-    DTensor<T> b(vecB, nR);
-    DTensor<T> xFull(nR);
-    DTensor<T> x(xFull, 0, 0, nC - 1);
-    DTensor<T> Ax(nR);
-    QRFactoriser<T> qr(temp);
+    DTensor <T> A(vecA, nR, nC, 1, rowMajor);
+    DTensor <T> b(vecB, nR);
+    DTensor <T> xFull(nR);
+    DTensor <T> x(xFull, 0, 0, nC - 1);
+    DTensor <T> Ax(nR);
+    QRFactoriser <T> qr(temp);
     A.deviceCopyTo(temp);
     int status = qr.factorise();
     EXPECT_EQ(status, 0);
@@ -1193,9 +1327,10 @@ void qrLeastSquares(T epsilon) {
     EXPECT_NEAR(nrm, 80.003169364198072, epsilon);  // From MatLab
 }
 
-TEST_F(QRTest, qrLeastSquares) {
-    qrLeastSquares<float>(PRECISION_LOW);
-    qrLeastSquares<double>(PRECISION_HIGH);
+TEST_F(QRTest, qrLeastSquares
+) {
+qrLeastSquares<float>(PRECISION_LOW);
+qrLeastSquares<double>(PRECISION_HIGH);
 }
 
 
@@ -1221,19 +1356,19 @@ void computeNullspaceTensor(T epsilon) {
                             1, 2, 3, 4, 2, 4, 6, 8, 3, 6, 9, 12,
                             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    DTensor<T> A(aData, 3, 4, 5);
-    Nullspace<T> ns(A);
-    DTensor<T> nA = ns.nullspace();
+    DTensor <T> A(aData, 3, 4, 5);
+    Nullspace <T> ns(A);
+    DTensor <T> nA = ns.nullspace();
     size_t nMats = nA.numMats();
     EXPECT_EQ(nMats, 5);
     for (size_t i = 0; i < nMats; i++) {
-        DTensor<T> nAi(nA, 2, i, i);
-        DTensor<T> Ai(A, 2, i, i);
-        DTensor<T> mustBeZero = Ai * nAi;
+        DTensor <T> nAi(nA, 2, i, i);
+        DTensor <T> Ai(A, 2, i, i);
+        DTensor <T> mustBeZero = Ai * nAi;
         EXPECT_LT(mustBeZero.normF(), epsilon);
 
-        DTensor<T> nAiTr = nAi.tr();
-        DTensor<T> mustBeEye = nAiTr * nAi;
+        DTensor <T> nAiTr = nAi.tr();
+        DTensor <T> mustBeEye = nAiTr * nAi;
         EXPECT_NEAR(1, mustBeEye(0, 0, 0), epsilon);
         for (size_t ir = 0; ir < mustBeEye.numRows(); ir++) {
             for (size_t ic = 0; ic < mustBeEye.numCols(); ic++) {
@@ -1245,9 +1380,10 @@ void computeNullspaceTensor(T epsilon) {
     }
 }
 
-TEST_F(NullspaceTest, computeNullspaceTensor) {
-    computeNullspaceTensor<float>(PRECISION_LOW);
-    computeNullspaceTensor<double>(PRECISION_HIGH);
+TEST_F(NullspaceTest, computeNullspaceTensor
+) {
+computeNullspaceTensor<float>(PRECISION_LOW);
+computeNullspaceTensor<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1262,15 +1398,16 @@ void computeNullspaceTrivial(T epsilon) {
                         1, 1, 1,
                         5, 6, 7,
                         9, 0, 3};
-    DTensor<T> A(data, 3, 3, 2, rowMajor);
-    Nullspace<T> nullA(A);
-    DTensor<T> N = nullA.nullspace();
+    DTensor <T> A(data, 3, 3, 2, rowMajor);
+    Nullspace <T> nullA(A);
+    DTensor <T> N = nullA.nullspace();
     EXPECT_EQ(N.normF(), 0);
 }
 
-TEST_F(NullspaceTest, computeNullspaceTrivial) {
-    computeNullspaceTrivial<float>(PRECISION_LOW);
-    computeNullspaceTrivial<double>(PRECISION_HIGH);
+TEST_F(NullspaceTest, computeNullspaceTrivial
+) {
+computeNullspaceTrivial<float>(PRECISION_LOW);
+computeNullspaceTrivial<double>(PRECISION_HIGH);
 }
 
 /* ---------------------------------------
@@ -1285,34 +1422,35 @@ void projectOnNullspaceTensor(T epsilon) {
     std::vector<T> mat{1, -2, 3, 4, -1, -1, -1,
                        1, 2, -3, 4, -1, -1, -1,
                        -1, 3, 5, -7, -1, -1, -1};
-    DTensor<T> A(m, n, 1);
+    DTensor <T> A(m, n, 1);
     A.upload(mat, rowMajor);
-    Nullspace<T> ns = Nullspace(A);
-    DTensor<T> N = ns.nullspace();
+    Nullspace <T> ns = Nullspace(A);
+    DTensor <T> N = ns.nullspace();
 
     // online
     std::vector<T> vec{1, 2, 3, 4, 5, 6, 7};
-    DTensor<T> x(vec, n);
-    DTensor<T> proj(x);
+    DTensor <T> x(vec, n);
+    DTensor <T> proj(x);
     ns.project(proj);
 
     // Testing that proj is indeed in ker A
-    DTensor<T> error(m, 1, 1, true);
+    DTensor <T> error(m, 1, 1, true);
     error.addAB(A, proj);
     EXPECT_TRUE(error.normF() < epsilon);
 
     // Orthogonality test (other - p) † (p - x)
     std::vector<T> h_other{1, -2, 5, 4, 0, 0, 0};
-    DTensor<T> other(h_other, n);
-    DTensor<T> y = N * other;
-    DTensor<T> delta1 = y - proj;
-    DTensor<T> delta2 = proj - x;
+    DTensor <T> other(h_other, n);
+    DTensor <T> y = N * other;
+    DTensor <T> delta1 = y - proj;
+    DTensor <T> delta2 = proj - x;
     EXPECT_LT(delta1.dotF(delta2), epsilon);
 }
 
-TEST_F(NullspaceTest, projectOnNullspaceTensor) {
-    projectOnNullspaceTensor<float>(PRECISION_LOW);
-    projectOnNullspaceTensor<double>(PRECISION_HIGH);
+TEST_F(NullspaceTest, projectOnNullspaceTensor
+) {
+projectOnNullspaceTensor<float>(PRECISION_LOW);
+projectOnNullspaceTensor<double>(PRECISION_HIGH);
 }
 
 
@@ -1350,9 +1488,10 @@ void givensAnnihilateElement(T epsilon) {
     }
 }
 
-TEST_F(GivensAnnihilatorTest, givensAnnihilateElement) {
-    givensAnnihilateElement<float>(PRECISION_LOW);
-    givensAnnihilateElement<double>(PRECISION_HIGH);
+TEST_F(GivensAnnihilatorTest, givensAnnihilateElement
+) {
+givensAnnihilateElement<float>(PRECISION_LOW);
+givensAnnihilateElement<double>(PRECISION_HIGH);
 }
 
 
@@ -1379,9 +1518,10 @@ void givensAnnihilateCorrectness(T epsilon) {
 
 }
 
-TEST_F(GivensAnnihilatorTest, givensAnnihilateCorrectness) {
-    givensAnnihilateCorrectness<double>(1e-14);
-    givensAnnihilateCorrectness<float>(1e-12);
+TEST_F(GivensAnnihilatorTest, givensAnnihilateCorrectness
+) {
+givensAnnihilateCorrectness<double>(1e-14);
+givensAnnihilateCorrectness<float>(1e-12);
 }
 
 


### PR DESCRIPTION
This is an alternative to PR #49; this is still WIP.

## Main Changes

- Introduce `T** m_d_ptrMatrices`, which is a raw pointer to the matrices of the tensor (to replace `pointersToMatrices`)

## TODOs

- [x] New memory management scheme (malloc/free)
- [x] `addAB`: use `gemm` when `nMats=1`
- [x] Slicing: set `m_d_ptrMatrix = nullptr` when slicing with `axis=0` or `axis=1`
- [x] Remove unit test `tensorPointersToMatrices` (method deprecation)
- [x] Get rid of `pointersToMatrices()` in `leastSquaresBatched`
- [x] `CholeskyBatchFactoriser`: get rid of `pointersToMatrices`
- [x] `CholeskyBatchFactoriser`: throw error if `nMats=1`
- [x] Reshaping: new test needed (e.g., reshape + multiply with `addAB`)
- [x] Unit test with reshaping and slicing

## Note

It probably makes sense to always have `m_d_ptrMatrix = nullptr` whenever `nMats=1` and throw an error when the user attempts to use any batched method with `nMats=1`.

## Associated Issues

- Closes #48