### PR TITLE
Set precision in DTensor::saveToFile properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Set precision in `DTensor::saveToFile` properly
-
+- `DTensor<T>::parseFromTextFile` throws `std::invalid_argument` if `T` is unsupported
 
 <!-- ---------------------
       v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ---------------------
+      v1.5.1
+     --------------------- -->
+## v1.5.1 - 29-11-2024
+
+### Fixed
+
+- Set precision in `DTensor::saveToFile` properly
+
+
+<!-- ---------------------
       v1.5.0
      --------------------- -->
 ## v1.5.0 - 27-11-2024

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -629,8 +629,9 @@ data_t<T> vectorFromFile(std::string path_to_file) {
             vecDataFromFile[i] = std::stoull(line.c_str());
         } else if constexpr (std::is_same_v<T, size_t>) {
             sscanf(line.c_str(), "%zu", &vecDataFromFile[i]);
+        }  else {
+            throw std::invalid_argument("data type not supported");
         }
-        // todo
 
         if (++i == numElements) break;
     }

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -653,8 +653,7 @@ void DTensor<T>::saveToFile(std::string pathToFile) {
     file << numRows() << std::endl << numCols() << std::endl << numMats() << std::endl;
     std::vector<T> myData(numEl()); download(myData);
     if constexpr (std::is_floating_point<T>::value) {
-        int prec = std::numeric_limits<T>::max_digits10 - 1;
-        file << std::setprecision(prec);
+        file << std::setprecision(std::numeric_limits<T>::max_digits10);
     }
     for(const T& el : myData) file << el << std::endl;
 }

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -122,9 +122,9 @@ TEST_F(TensorTest, randomTensorCreation) {
 
 TEMPLATE_WITH_TYPE_T
 void parseTensorFromFile() {
-    size_t n_runs = 20;
+    size_t n_runs = 10;
     for (size_t i = 0; i < n_runs; i++) {
-        size_t nR = 20, nC = 40, nM = 60;
+        size_t nR = 20, nC = 40, nM = 6;
         auto r = DTensor<T>::createRandomTensor(nR, nC, nM, -1, 1);
         std::string fName = "myTest.dtensor";
         r.saveToFile(fName);
@@ -141,6 +141,19 @@ void parseTensorFromFile() {
 TEST_F(TensorTest, parseTensorFromFile) {
     parseTensorFromFile<float>();
     parseTensorFromFile<double>();
+}
+
+TEST_F(TensorTest, parseTensorUnsupportedDataType) {
+    size_t nR = 20, nC = 40, nM = 60;
+    auto r = DTensor<double>::createRandomTensor(nR, nC, nM, -1, 1);
+    std::string fName = "myTest.dtensor";
+    r.saveToFile(fName);
+    try {
+        auto a = DTensor<char>::parseFromTextFile(fName);
+    } catch (const std::invalid_argument& _e) {
+        return;
+    }
+    FAIL();
 }
 
 /* ---------------------------------------

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -148,12 +148,7 @@ TEST_F(TensorTest, parseTensorUnsupportedDataType) {
     auto r = DTensor<double>::createRandomTensor(nR, nC, nM, -1, 1);
     std::string fName = "myTest.dtensor";
     r.saveToFile(fName);
-    try {
-        auto a = DTensor<char>::parseFromTextFile(fName);
-    } catch (const std::invalid_argument& _e) {
-        return;
-    }
-    FAIL();
+    EXPECT_THROW(DTensor<char>::parseFromTextFile(fName), std::invalid_argument);
 }
 
 /* ---------------------------------------

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -122,17 +122,20 @@ TEST_F(TensorTest, randomTensorCreation) {
 
 TEMPLATE_WITH_TYPE_T
 void parseTensorFromFile() {
-    size_t nR = 20, nC = 40, nM = 60;
-    auto r = DTensor<T>::createRandomTensor(nR, nC, nM, -1, 1);
-    std::string fName = "myTest.dtensor";
-    r.saveToFile(fName);
-    auto a = DTensor<T>::parseFromTextFile(fName);
-    EXPECT_EQ(nR, a.numRows());
-    EXPECT_EQ(nC, a.numCols());
-    EXPECT_EQ(nM, a.numMats());
-    auto diff = a - r;
-    T err = diff.maxAbs();
-    EXPECT_LT(err, 2*std::numeric_limits<T>::epsilon());
+    size_t n_runs = 20;
+    for (size_t i = 0; i < n_runs; i++) {
+        size_t nR = 20, nC = 40, nM = 60;
+        auto r = DTensor<T>::createRandomTensor(nR, nC, nM, -1, 1);
+        std::string fName = "myTest.dtensor";
+        r.saveToFile(fName);
+        auto a = DTensor<T>::parseFromTextFile(fName);
+        EXPECT_EQ(nR, a.numRows());
+        EXPECT_EQ(nC, a.numCols());
+        EXPECT_EQ(nM, a.numMats());
+        auto diff = a - r;
+        T err = diff.maxAbs();
+        EXPECT_LT(err, 2 * std::numeric_limits<T>::epsilon());
+    }
 }
 
 TEST_F(TensorTest, parseTensorFromFile) {


### PR DESCRIPTION
## Main Changes

- Set precision in `DTensor::saveToFile` properly
- `DTensor<T>::parseFromTextFile` throws `std::invalid_argument` if `T` is unsupported


## Associated Issues
None
