### PR TITLE
Serialisation: text and binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
- - Method `parseFromFile` renamed to `parseFromFile` (supports text and binary formats)
+ - Method `parseFromTextFile` renamed to `parseFromFile` (supports text and binary formats)
 
 
 <!-- ---------------------
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Quick bug bix in `DTensor::parseFromFile` (passing storage mode to `vectorFromTextFile`)
+- Quick bug bix in `DTensor::parseFromTextFile` (passing storage mode to `vectorFromTextFile`)
 
 
 <!-- ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ---------------------
+      v1.6.0
+     --------------------- -->
+## v1.6.0 - Unreleased
+
+### Added
+
+- Method `saveToFile` becomes `DTensor<T>::saveToFile(std::string pathToFile, Serialisation ser)`, i.e., the user can 
+  choose whether to save the file as a text (ASCII) file, or a binary one
+
+### Changed
+
+ - Method `parseFromFile` renamed to `parseFromFile` (supports text and binary formats)
+
+
+<!-- ---------------------
       v1.5.2
      --------------------- -->
 ## v1.5.2 - 1-12-2024
 
 ### Fixed
 
-- Quick bug bix in `DTensor::parseFromTextFile` (passing storage mode to `vectorFromFile`)
+- Quick bug bix in `DTensor::parseFromFile` (passing storage mode to `vectorFromTextFile`)
 
 
 <!-- ---------------------
@@ -23,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Set precision in `DTensor::saveToFile` properly
-- `DTensor<T>::parseFromTextFile` throws `std::invalid_argument` if `T` is unsupported
+- `DTensor<T>::parseFromFile` throws `std::invalid_argument` if `T` is unsupported
 
 <!-- ---------------------
       v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ---------------------
       v1.6.0
      --------------------- -->
-## v1.6.0 - Unreleased
+## v1.6.0 - 2-12-2024
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ data (one entry per line)
 To save a tensor in a file, simply call `DTensor::saveToFile(filename)`.
 
 If the file extension is `.bt` (binary tensor), the data will be stored in binary format.
+The structure of the binary encoding is similar to that of the text encoding:
+the first three `uint64_t`-sized positions correspond to the number of rows, columns
+and matrices, followed by the elements of the tensor.
 
 To load a tensor from a file, the static function `DTensor<T>::parseFromFile(filename)` can be used. For example:
 
@@ -268,7 +271,9 @@ To load a tensor from a file, the static function `DTensor<T>::parseFromFile(fil
 auto z = DTensor<double>::parseFromFile("path/to/my.dtensor")
 ```
 
-If necessary, you can provide a second argument to `parseFromFile` to specify the order in which the data are stored (the `StorageMode`). 
+If necessary, you can provide a second argument to `parseFromFile` to specify the order in which the data are stored (the `StorageMode`).
+
+Soon we will release a Python API for reading and serialising (numpy) arrays to `.bt` files.  
 
 ## 2. Cholesky factorisation and system solution
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ The `DTensor` `B` will be overwritten with the solution.
 
 ### 1.8. Saving and loading tensors
 
-Tensor data can be stored in simple text files which have the following structure
+Tensor data can be stored in simple text files or binary files. 
+The text-based format has the following structure
 
 ```text
 number_of_rows
@@ -259,13 +260,15 @@ data (one entry per line)
 
 To save a tensor in a file, simply call `DTensor::saveToFile(filename)`.
 
-To load a tensor from a file, the static function `DTensor<T>::parseFromTextFile(filename)` can be used. For example:
+If the file extension is `.bt` (binary tensor), the data will be stored in binary format.
+
+To load a tensor from a file, the static function `DTensor<T>::parseFromFile(filename)` can be used. For example:
 
 ```c++
-auto z = DTensor<double>::parseFromTextFile("path/to/my.dtensor")
+auto z = DTensor<double>::parseFromFile("path/to/my.dtensor")
 ```
 
-If necessary, you can provide a second argument to `parseFromTextFile` to specify the order in which the data are stored (the `StorageMode`). 
+If necessary, you can provide a second argument to `parseFromFile` to specify the order in which the data are stored (the `StorageMode`). 
 
 ## 2. Cholesky factorisation and system solution
 

--- a/include/tensor.cuh
+++ b/include/tensor.cuh
@@ -257,6 +257,8 @@ public:
      *
      * This static function reads data from a text file, creates a DTensor and uploads the data to the device.
      *
+     * The data may be stored in a text file or a binary file. Binary files must have the extension .bt.
+     *
      * @param path_to_file path to file as string
      * @param mode storage mode (default: StorageMode::defaultMajor)
      * @return instance of DTensor
@@ -506,7 +508,12 @@ public:
     /**
      * Saves the current instance of DTensor to a (text) file
      *
-     * @param pathToFile
+     * If the file extension is .bt, the data will be stored in a binary file.
+     * Writing to and reading from a binary file is significantly faster and
+     * the generated binary files tend to have a smaller size (about 40% of the
+     * size of text files for data of type double and float).
+     *
+     * @param pathToFile path to file
      */
     void saveToFile(std::string pathToFile);
 

--- a/main.cu
+++ b/main.cu
@@ -6,9 +6,15 @@
 
 
 int main() {
-    auto z = DTensor<size_t>::parseFromTextFile("../test/data/my.dtensor",
-                                                StorageMode::rowMajor);
-    std::cout << z;
-    z.saveToFile("hohoho.dtensor");
+    /* Write to binary file */
+    auto r = DTensor<double>::createRandomTensor(3, 6, 4, -1, 1);
+    std::string fName = "tensor.bt"; // binary tensor file extension: .bt
+    r.saveToFile(fName);
+
+    /* Parse binary file */
+    auto recov = DTensor<double>::parseFromFile(fName);
+    auto err = r - recov;
+    std::cout << "max error : " << err.maxAbs();
+
     return 0;
 }

--- a/test/testTensor.cu
+++ b/test/testTensor.cu
@@ -117,7 +117,7 @@ TEST_F(TensorTest, randomTensorCreation) {
 }
 
 /* ---------------------------------------
- * Save to file and parse
+ * Save to file and parse (text)
  * --------------------------------------- */
 
 TEMPLATE_WITH_TYPE_T
@@ -128,7 +128,7 @@ void parseTensorFromFile() {
         auto r = DTensor<T>::createRandomTensor(nR, nC, nM, -1, 1);
         std::string fName = "myTest.dtensor";
         r.saveToFile(fName);
-        auto a = DTensor<T>::parseFromTextFile(fName);
+        auto a = DTensor<T>::parseFromFile(fName);
         EXPECT_EQ(nR, a.numRows());
         EXPECT_EQ(nC, a.numCols());
         EXPECT_EQ(nM, a.numMats());
@@ -148,7 +148,31 @@ TEST_F(TensorTest, parseTensorUnsupportedDataType) {
     auto r = DTensor<double>::createRandomTensor(nR, nC, nM, -1, 1);
     std::string fName = "myTest.dtensor";
     r.saveToFile(fName);
-    EXPECT_THROW(DTensor<char>::parseFromTextFile(fName), std::invalid_argument);
+    EXPECT_THROW(DTensor<char>::parseFromFile(fName), std::invalid_argument);
+}
+
+/* ---------------------------------------
+ * Save to file and parse (binary)
+ * --------------------------------------- */
+
+TEMPLATE_WITH_TYPE_T
+void parseTensorFromFileBinary() {
+    size_t nR = 20, nC = 40, nM = 6;
+    auto r = DTensor<T>::createRandomTensor(nR, nC, nM, -1, 1);
+    std::string fName = "myTest.bt";
+    r.saveToFile(fName);
+    auto a = DTensor<T>::parseFromFile(fName);
+    EXPECT_EQ(nR, a.numRows());
+    EXPECT_EQ(nC, a.numCols());
+    EXPECT_EQ(nM, a.numMats());
+    auto diff = a - r;
+    T err = diff.maxAbs();
+    EXPECT_LT(err, 2 * std::numeric_limits<T>::epsilon());
+}
+
+TEST_F(TensorTest, parseTensorFromFileBinary) {
+    parseTensorFromFileBinary<float>();
+    parseTensorFromFileBinary<double>();
 }
 
 /* ---------------------------------------


### PR DESCRIPTION
## Main Changes

Support for binary encoding, which is more reliable, faster and leads to smaller files

- Support for binary encoding (`.bt` files)
- Renamed `parseFromTextFile` to `parseFromFile` (seamlessly supports text and binary encodings)
- Updated `README.md`
- Version 1.6.0 to be released


## Example

```c++
/* Write to binary file */
auto r = DTensor<double>::createRandomTensor(3, 6, 4, -1, 1);
std::string fName = "tensor.bt"; // binary tensor file extension: .bt
r.saveToFile(fName);

/* Parse binary file */
auto recov = DTensor<double>::parseFromFile(fName);
auto err = r - recov;
std::cout << "max error : " << err.maxAbs();
```


## Performance

| Encoding | Data type | Dimensions | Size (MB) | Write time (ms) | Read time (ms) |
| ---- | ---- | ---- | ---- | ---- |  ---- |
| Binary  | `double` | 1000 x 1000 x 2 | 16.00 | 84 | 64 |
| Text | `double` | 1000 x 1000 x 2 | 38.78 | 4751 | 611 |
| Binary | `float` | 1000 x 1000 x 2 | 16.00 | 74 | 58 |
| Text | `float` | 1000 x 1000 x 2 | 38.78 | 4320 | 474 |

## From GPutils to Python

To read a `.bt` file in Python, use the function

```python
def read_array_from_file(path, dt='d'):
    with open(path, 'rb') as f:
        nr = int.from_bytes(f.read(8), byteorder='little', signed=False)
        nc = int.from_bytes(f.read(8), byteorder='little', signed=False)
        nm = int.from_bytes(f.read(8), byteorder='little', signed=False)
        dat = np.fromfile(f, dtype=np.dtype(dt))
    return dat
```

## From Python to GPUtils

```python
import numpy as np

nr, nc, mm = 5, 6, 2
ne = nr * nc * nm
x = np.linspace(-100.0, 100.0, ne, dtype=np.dtype('d'))
with open('p.bt', 'wb') as f:
    f.write(nr.to_bytes(8, 'little'))
    f.write(nc.to_bytes(8, 'little'))
    f.write(nm.to_bytes(8, 'little'))
    x.tofile(f)
```

## Associated Issues

- Closes #58
