### PR TITLE
Troubleshooting: CI fails on Orin

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -23,6 +23,7 @@ tests() {
     # ------------------------------------
     pushd python
     export PYTHONPATH=.
+    which python
     python -m venv venv
     source venv/bin/activate
     pip install --upgrade pip

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -24,7 +24,7 @@ tests() {
     pushd python
     export PYTHONPATH=.
     which python
-    python -m venv venv
+    /usr/bin/python -m venv venv
     source venv/bin/activate
     pip install --upgrade pip
     pip install .


### PR DESCRIPTION
## Main Changes

Troubleshooting: CI fails on Orin

Problem solved: changed `python` to `/usr/bin/python` (not sure why Orin started to act out)


